### PR TITLE
feat: ドメイン層: 駒クラスの実装（Piece）

### DIFF
--- a/src/domain/models/piece/factory.test.ts
+++ b/src/domain/models/piece/factory.test.ts
@@ -1,0 +1,118 @@
+import { createPiece } from './factory';
+import { PieceType, Player, Position } from './types';
+import {
+  King,
+  Rook,
+  Bishop,
+  Gold,
+  Silver,
+  Knight,
+  Lance,
+  Pawn,
+  Dragon,
+  Horse,
+  PromotedSilver,
+  PromotedKnight,
+  PromotedLance,
+  Tokin,
+} from './pieces';
+
+describe('createPiece ファクトリ関数', () => {
+  const position: Position = { row: 5, column: 5 };
+
+  it('玉を正しく作成できる', () => {
+    const piece = createPiece(PieceType.KING, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(King);
+    expect(piece.type).toBe(PieceType.KING);
+    expect(piece.player).toBe(Player.SENTE);
+    expect(piece.position).toEqual(position);
+  });
+
+  it('飛車を正しく作成できる', () => {
+    const piece = createPiece(PieceType.ROOK, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(Rook);
+    expect(piece.type).toBe(PieceType.ROOK);
+  });
+
+  it('角を正しく作成できる', () => {
+    const piece = createPiece(PieceType.BISHOP, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(Bishop);
+    expect(piece.type).toBe(PieceType.BISHOP);
+  });
+
+  it('金を正しく作成できる', () => {
+    const piece = createPiece(PieceType.GOLD, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(Gold);
+    expect(piece.type).toBe(PieceType.GOLD);
+  });
+
+  it('銀を正しく作成できる', () => {
+    const piece = createPiece(PieceType.SILVER, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(Silver);
+    expect(piece.type).toBe(PieceType.SILVER);
+  });
+
+  it('桂馬を正しく作成できる', () => {
+    const piece = createPiece(PieceType.KNIGHT, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(Knight);
+    expect(piece.type).toBe(PieceType.KNIGHT);
+  });
+
+  it('香車を正しく作成できる', () => {
+    const piece = createPiece(PieceType.LANCE, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(Lance);
+    expect(piece.type).toBe(PieceType.LANCE);
+  });
+
+  it('歩を正しく作成できる', () => {
+    const piece = createPiece(PieceType.PAWN, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(Pawn);
+    expect(piece.type).toBe(PieceType.PAWN);
+  });
+
+  it('竜を正しく作成できる', () => {
+    const piece = createPiece(PieceType.DRAGON, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(Dragon);
+    expect(piece.type).toBe(PieceType.DRAGON);
+  });
+
+  it('馬を正しく作成できる', () => {
+    const piece = createPiece(PieceType.HORSE, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(Horse);
+    expect(piece.type).toBe(PieceType.HORSE);
+  });
+
+  it('成銀を正しく作成できる', () => {
+    const piece = createPiece(PieceType.PROMOTED_SILVER, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(PromotedSilver);
+    expect(piece.type).toBe(PieceType.PROMOTED_SILVER);
+  });
+
+  it('成桂を正しく作成できる', () => {
+    const piece = createPiece(PieceType.PROMOTED_KNIGHT, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(PromotedKnight);
+    expect(piece.type).toBe(PieceType.PROMOTED_KNIGHT);
+  });
+
+  it('成香を正しく作成できる', () => {
+    const piece = createPiece(PieceType.PROMOTED_LANCE, Player.SENTE, position);
+    expect(piece).toBeInstanceOf(PromotedLance);
+    expect(piece.type).toBe(PieceType.PROMOTED_LANCE);
+  });
+
+  it('と金を正しく作成できる', () => {
+    const piece = createPiece(PieceType.TOKIN, Player.GOTE, position);
+    expect(piece).toBeInstanceOf(Tokin);
+    expect(piece.type).toBe(PieceType.TOKIN);
+  });
+
+  it('位置なしで駒を作成できる', () => {
+    const piece = createPiece(PieceType.GOLD, Player.SENTE);
+    expect(piece.position).toBeNull();
+  });
+
+  it('不明な駒の種類でエラーを投げる', () => {
+    expect(() => createPiece('UNKNOWN' as PieceType, Player.SENTE))
+      .toThrow('不明な駒の種類: UNKNOWN');
+  });
+});

--- a/src/domain/models/piece/factory.ts
+++ b/src/domain/models/piece/factory.ts
@@ -1,0 +1,64 @@
+import { PieceType, Player, Position } from './types';
+import { IPiece } from './interface';
+import {
+  King,
+  Rook,
+  Bishop,
+  Gold,
+  Silver,
+  Knight,
+  Lance,
+  Pawn,
+  Dragon,
+  Horse,
+  PromotedSilver,
+  PromotedKnight,
+  PromotedLance,
+  Tokin,
+} from './pieces';
+
+/**
+ * 駒を作成するファクトリ関数
+ * @param type 駒の種類
+ * @param player プレイヤー
+ * @param position 位置（オプション）
+ * @returns 作成された駒
+ */
+export function createPiece(
+  type: PieceType,
+  player: Player,
+  position: Position | null = null
+): IPiece {
+  switch (type) {
+    case PieceType.KING:
+      return new King(player, position);
+    case PieceType.ROOK:
+      return new Rook(player, position);
+    case PieceType.BISHOP:
+      return new Bishop(player, position);
+    case PieceType.GOLD:
+      return new Gold(player, position);
+    case PieceType.SILVER:
+      return new Silver(player, position);
+    case PieceType.KNIGHT:
+      return new Knight(player, position);
+    case PieceType.LANCE:
+      return new Lance(player, position);
+    case PieceType.PAWN:
+      return new Pawn(player, position);
+    case PieceType.DRAGON:
+      return new Dragon(player, position);
+    case PieceType.HORSE:
+      return new Horse(player, position);
+    case PieceType.PROMOTED_SILVER:
+      return new PromotedSilver(player, position);
+    case PieceType.PROMOTED_KNIGHT:
+      return new PromotedKnight(player, position);
+    case PieceType.PROMOTED_LANCE:
+      return new PromotedLance(player, position);
+    case PieceType.TOKIN:
+      return new Tokin(player, position);
+    default:
+      throw new Error(`不明な駒の種類: ${type}`);
+  }
+}

--- a/src/domain/models/piece/index.ts
+++ b/src/domain/models/piece/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './interface';
+export * from './piece';
+export * from './pieces';
+export * from './factory';

--- a/src/domain/models/piece/interface.ts
+++ b/src/domain/models/piece/interface.ts
@@ -1,0 +1,61 @@
+import { PieceType, Player, Position, Move } from './types';
+
+/**
+ * 駒のインターフェース
+ */
+export interface IPiece {
+  /** 駒の種類 */
+  readonly type: PieceType;
+  
+  /** 駒の所有者 */
+  readonly player: Player;
+  
+  /** 現在の位置 */
+  readonly position: Position | null;
+  
+  /**
+   * 指定された盤面で移動可能な位置を計算
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[];
+  
+  /**
+   * 成り駒への変換が可能かチェック
+   * @param to 移動先の位置
+   * @returns 成り可能な場合true
+   */
+  canPromote(to: Position): boolean;
+  
+  /**
+   * 成り駒に変換
+   * @returns 成り駒のインスタンス
+   */
+  promote(): IPiece;
+  
+  /**
+   * 駒を複製
+   * @param position 新しい位置（省略時は現在位置）
+   * @returns 複製された駒
+   */
+  clone(position?: Position): IPiece;
+}
+
+/**
+ * 盤面のインターフェース（簡易版）
+ */
+export interface IBoard {
+  /**
+   * 指定位置の駒を取得
+   * @param position 位置
+   * @returns 駒またはnull
+   */
+  getPieceAt(position: Position): IPiece | null;
+  
+  /**
+   * 指定位置が盤面内かチェック
+   * @param position 位置
+   * @returns 盤面内の場合true
+   */
+  isValidPosition(position: Position): boolean;
+}

--- a/src/domain/models/piece/piece.test.ts
+++ b/src/domain/models/piece/piece.test.ts
@@ -1,0 +1,200 @@
+import { Piece } from './piece';
+import { PieceType, Player, Position } from './types';
+import { IBoard, IPiece } from './interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Piece基底クラス', () => {
+  describe('コンストラクタ', () => {
+    it('駒の種類、プレイヤー、位置を正しく設定できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const piece = new Piece(PieceType.GOLD, Player.SENTE, position);
+
+      expect(piece.type).toBe(PieceType.GOLD);
+      expect(piece.player).toBe(Player.SENTE);
+      expect(piece.position).toEqual(position);
+    });
+
+    it('位置なしで駒を作成できる', () => {
+      const piece = new Piece(PieceType.SILVER, Player.GOTE);
+
+      expect(piece.type).toBe(PieceType.SILVER);
+      expect(piece.player).toBe(Player.GOTE);
+      expect(piece.position).toBeNull();
+    });
+  });
+
+  describe('clone', () => {
+    it('駒を正しく複製できる', () => {
+      const originalPosition: Position = { row: 3, column: 3 };
+      const original = new Piece(PieceType.ROOK, Player.SENTE, originalPosition);
+      const clone = original.clone();
+
+      expect(clone.type).toBe(original.type);
+      expect(clone.player).toBe(original.player);
+      expect(clone.position).toEqual(original.position);
+      expect(clone).not.toBe(original);
+    });
+
+    it('新しい位置で駒を複製できる', () => {
+      const original = new Piece(PieceType.BISHOP, Player.GOTE, { row: 2, column: 2 });
+      const newPosition: Position = { row: 6, column: 6 };
+      const clone = original.clone(newPosition);
+
+      expect(clone.type).toBe(original.type);
+      expect(clone.player).toBe(original.player);
+      expect(clone.position).toEqual(newPosition);
+    });
+  });
+
+  describe('成り駒の判定', () => {
+    describe('先手の場合', () => {
+      it('敵陣（1-3段目）に入る場合、成り可能', () => {
+        const piece = new Piece(PieceType.SILVER, Player.SENTE, { row: 4, column: 5 });
+        
+        expect(piece.canPromote({ row: 3, column: 5 })).toBe(true);
+        expect(piece.canPromote({ row: 2, column: 5 })).toBe(true);
+        expect(piece.canPromote({ row: 1, column: 5 })).toBe(true);
+      });
+
+      it('敵陣から出る場合も成り可能', () => {
+        const piece = new Piece(PieceType.SILVER, Player.SENTE, { row: 3, column: 5 });
+        
+        expect(piece.canPromote({ row: 4, column: 5 })).toBe(true);
+      });
+
+      it('敵陣外から敵陣外への移動は成り不可', () => {
+        const piece = new Piece(PieceType.SILVER, Player.SENTE, { row: 5, column: 5 });
+        
+        expect(piece.canPromote({ row: 6, column: 5 })).toBe(false);
+      });
+    });
+
+    describe('後手の場合', () => {
+      it('敵陣（7-9段目）に入る場合、成り可能', () => {
+        const piece = new Piece(PieceType.SILVER, Player.GOTE, { row: 6, column: 5 });
+        
+        expect(piece.canPromote({ row: 7, column: 5 })).toBe(true);
+        expect(piece.canPromote({ row: 8, column: 5 })).toBe(true);
+        expect(piece.canPromote({ row: 9, column: 5 })).toBe(true);
+      });
+
+      it('敵陣から出る場合も成り可能', () => {
+        const piece = new Piece(PieceType.SILVER, Player.GOTE, { row: 7, column: 5 });
+        
+        expect(piece.canPromote({ row: 6, column: 5 })).toBe(true);
+      });
+    });
+
+    it('金と玉は成れない', () => {
+      const goldPiece = new Piece(PieceType.GOLD, Player.SENTE, { row: 4, column: 5 });
+      const kingPiece = new Piece(PieceType.KING, Player.SENTE, { row: 4, column: 5 });
+      
+      expect(goldPiece.canPromote({ row: 1, column: 5 })).toBe(false);
+      expect(kingPiece.canPromote({ row: 1, column: 5 })).toBe(false);
+    });
+
+    it('すでに成り駒の場合は成れない', () => {
+      const dragonPiece = new Piece(PieceType.DRAGON, Player.SENTE, { row: 4, column: 5 });
+      
+      expect(dragonPiece.canPromote({ row: 1, column: 5 })).toBe(false);
+    });
+
+    it('持ち駒（位置なし）は成れない', () => {
+      const piece = new Piece(PieceType.SILVER, Player.SENTE);
+      
+      expect(piece.canPromote({ row: 1, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('成り駒への変換', () => {
+    it('飛車を竜に変換できる', () => {
+      const rook = new Piece(PieceType.ROOK, Player.SENTE, { row: 5, column: 5 });
+      const dragon = rook.promote();
+
+      expect(dragon.type).toBe(PieceType.DRAGON);
+      expect(dragon.player).toBe(Player.SENTE);
+      expect(dragon.position).toEqual(rook.position);
+    });
+
+    it('角を馬に変換できる', () => {
+      const bishop = new Piece(PieceType.BISHOP, Player.GOTE, { row: 5, column: 5 });
+      const horse = bishop.promote();
+
+      expect(horse.type).toBe(PieceType.HORSE);
+    });
+
+    it('銀を成銀に変換できる', () => {
+      const silver = new Piece(PieceType.SILVER, Player.SENTE, { row: 5, column: 5 });
+      const promotedSilver = silver.promote();
+
+      expect(promotedSilver.type).toBe(PieceType.PROMOTED_SILVER);
+    });
+
+    it('桂馬を成桂に変換できる', () => {
+      const knight = new Piece(PieceType.KNIGHT, Player.SENTE, { row: 5, column: 5 });
+      const promotedKnight = knight.promote();
+
+      expect(promotedKnight.type).toBe(PieceType.PROMOTED_KNIGHT);
+    });
+
+    it('香車を成香に変換できる', () => {
+      const lance = new Piece(PieceType.LANCE, Player.SENTE, { row: 5, column: 5 });
+      const promotedLance = lance.promote();
+
+      expect(promotedLance.type).toBe(PieceType.PROMOTED_LANCE);
+    });
+
+    it('歩をと金に変換できる', () => {
+      const pawn = new Piece(PieceType.PAWN, Player.SENTE, { row: 5, column: 5 });
+      const tokin = pawn.promote();
+
+      expect(tokin.type).toBe(PieceType.TOKIN);
+    });
+
+    it('金と玉は成り駒に変換できない（例外をスロー）', () => {
+      const gold = new Piece(PieceType.GOLD, Player.SENTE, { row: 5, column: 5 });
+      const king = new Piece(PieceType.KING, Player.SENTE, { row: 5, column: 5 });
+
+      expect(() => gold.promote()).toThrow('この駒は成ることができません');
+      expect(() => king.promote()).toThrow('この駒は成ることができません');
+    });
+
+    it('すでに成り駒の場合は変換できない（例外をスロー）', () => {
+      const dragon = new Piece(PieceType.DRAGON, Player.SENTE, { row: 5, column: 5 });
+
+      expect(() => dragon.promote()).toThrow('この駒は成ることができません');
+    });
+  });
+
+  describe('基底クラスのgetValidMoves', () => {
+    it('基底クラスでは空配列を返す', () => {
+      const piece = new Piece(PieceType.GOLD, Player.SENTE, { row: 5, column: 5 });
+      const board = new MockBoard();
+
+      expect(piece.getValidMoves(board)).toEqual([]);
+    });
+  });
+});

--- a/src/domain/models/piece/piece.ts
+++ b/src/domain/models/piece/piece.ts
@@ -1,0 +1,102 @@
+import { IPiece, IBoard } from './interface';
+import { PieceType, Player, Position, Move } from './types';
+
+/**
+ * 駒の基底クラス
+ */
+export class Piece implements IPiece {
+  readonly type: PieceType;
+  readonly player: Player;
+  readonly position: Position | null;
+
+  constructor(type: PieceType, player: Player, position: Position | null = null) {
+    this.type = type;
+    this.player = player;
+    this.position = position;
+  }
+
+  /**
+   * 移動可能な位置を計算（基底クラスでは空配列）
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    return [];
+  }
+
+  /**
+   * 成り駒への変換が可能かチェック
+   * @param to 移動先の位置
+   * @returns 成り可能な場合true
+   */
+  canPromote(to: Position): boolean {
+    // 持ち駒は成れない
+    if (!this.position) {
+      return false;
+    }
+
+    // 金と玉は成れない
+    if (this.type === PieceType.GOLD || this.type === PieceType.KING) {
+      return false;
+    }
+
+    // すでに成り駒は成れない
+    if (this.isPromoted()) {
+      return false;
+    }
+
+    // 先手の場合：敵陣は1-3段目
+    if (this.player === Player.SENTE) {
+      return to.row <= 3 || this.position.row <= 3;
+    }
+    
+    // 後手の場合：敵陣は7-9段目
+    return to.row >= 7 || this.position.row >= 7;
+  }
+
+  /**
+   * 成り駒に変換
+   * @returns 成り駒のインスタンス
+   */
+  promote(): IPiece {
+    const promotionMap: Partial<Record<PieceType, PieceType>> = {
+      [PieceType.ROOK]: PieceType.DRAGON,
+      [PieceType.BISHOP]: PieceType.HORSE,
+      [PieceType.SILVER]: PieceType.PROMOTED_SILVER,
+      [PieceType.KNIGHT]: PieceType.PROMOTED_KNIGHT,
+      [PieceType.LANCE]: PieceType.PROMOTED_LANCE,
+      [PieceType.PAWN]: PieceType.TOKIN,
+    };
+
+    const promotedType = promotionMap[this.type];
+    if (!promotedType) {
+      throw new Error('この駒は成ることができません');
+    }
+
+    return new Piece(promotedType, this.player, this.position);
+  }
+
+  /**
+   * 駒を複製
+   * @param position 新しい位置（省略時は現在位置）
+   * @returns 複製された駒
+   */
+  clone(position?: Position): IPiece {
+    return new Piece(this.type, this.player, position ?? this.position);
+  }
+
+  /**
+   * 駒がすでに成り駒かチェック
+   * @returns 成り駒の場合true
+   */
+  private isPromoted(): boolean {
+    return [
+      PieceType.DRAGON,
+      PieceType.HORSE,
+      PieceType.PROMOTED_SILVER,
+      PieceType.PROMOTED_KNIGHT,
+      PieceType.PROMOTED_LANCE,
+      PieceType.TOKIN,
+    ].includes(this.type);
+  }
+}

--- a/src/domain/models/piece/pieces/bishop.test.ts
+++ b/src/domain/models/piece/pieces/bishop.test.ts
@@ -1,0 +1,158 @@
+import { Bishop } from './bishop';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Bishop（角）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく角を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const bishop = new Bishop(Player.SENTE, position);
+
+      expect(bishop.type).toBe(PieceType.BISHOP);
+      expect(bishop.player).toBe(Player.SENTE);
+      expect(bishop.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    it('斜めに自由に移動できる', () => {
+      const board = new MockBoard();
+      const bishop = new Bishop(Player.SENTE, { row: 5, column: 5 });
+      board.setPieceAt({ row: 5, column: 5 }, bishop);
+
+      const moves = bishop.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 左上方向
+      expect(destinations).toContainEqual({ row: 4, column: 4 });
+      expect(destinations).toContainEqual({ row: 3, column: 3 });
+      expect(destinations).toContainEqual({ row: 2, column: 2 });
+      expect(destinations).toContainEqual({ row: 1, column: 1 });
+      
+      // 右上方向
+      expect(destinations).toContainEqual({ row: 4, column: 6 });
+      expect(destinations).toContainEqual({ row: 3, column: 7 });
+      expect(destinations).toContainEqual({ row: 2, column: 8 });
+      expect(destinations).toContainEqual({ row: 1, column: 9 });
+      
+      // 左下方向
+      expect(destinations).toContainEqual({ row: 6, column: 4 });
+      expect(destinations).toContainEqual({ row: 7, column: 3 });
+      expect(destinations).toContainEqual({ row: 8, column: 2 });
+      expect(destinations).toContainEqual({ row: 9, column: 1 });
+      
+      // 右下方向
+      expect(destinations).toContainEqual({ row: 6, column: 6 });
+      expect(destinations).toContainEqual({ row: 7, column: 7 });
+      expect(destinations).toContainEqual({ row: 8, column: 8 });
+      expect(destinations).toContainEqual({ row: 9, column: 9 });
+      
+      expect(destinations).toHaveLength(16);
+      
+      // 縦横には移動できない
+      expect(destinations).not.toContainEqual({ row: 4, column: 5 });
+      expect(destinations).not.toContainEqual({ row: 5, column: 4 });
+    });
+
+    it('他の駒を飛び越えることはできない', () => {
+      const board = new MockBoard();
+      const bishop = new Bishop(Player.SENTE, { row: 5, column: 5 });
+      const blockingPiece = new Bishop(Player.GOTE, { row: 3, column: 3 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, bishop);
+      board.setPieceAt({ row: 3, column: 3 }, blockingPiece);
+
+      const moves = bishop.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 敵の駒の位置までは移動できる
+      expect(destinations).toContainEqual({ row: 3, column: 3 });
+      // その先には移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 2 });
+      expect(destinations).not.toContainEqual({ row: 1, column: 1 });
+    });
+
+    it('味方の駒の手前までしか移動できない', () => {
+      const board = new MockBoard();
+      const bishop = new Bishop(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Bishop(Player.SENTE, { row: 3, column: 3 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, bishop);
+      board.setPieceAt({ row: 3, column: 3 }, allyPiece);
+
+      const moves = bishop.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 味方の駒の手前まで
+      expect(destinations).toContainEqual({ row: 4, column: 4 });
+      // 味方の駒の位置には移動できない
+      expect(destinations).not.toContainEqual({ row: 3, column: 3 });
+      // その先にも移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 2 });
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const bishop = new Bishop(Player.SENTE);
+
+      const moves = bishop.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('敵陣に入る時に成れる', () => {
+      const bishop = new Bishop(Player.SENTE, { row: 4, column: 5 });
+      
+      expect(bishop.canPromote({ row: 3, column: 4 })).toBe(true);
+      expect(bishop.canPromote({ row: 2, column: 3 })).toBe(true);
+    });
+
+    it('敵陣から出る時も成れる', () => {
+      const bishop = new Bishop(Player.SENTE, { row: 3, column: 5 });
+      
+      expect(bishop.canPromote({ row: 4, column: 6 })).toBe(true);
+    });
+
+    it('敵陣内での移動でも成れる', () => {
+      const bishop = new Bishop(Player.SENTE, { row: 2, column: 5 });
+      
+      expect(bishop.canPromote({ row: 1, column: 4 })).toBe(true);
+    });
+  });
+
+  describe('promote', () => {
+    it('角を馬に変換できる', () => {
+      const bishop = new Bishop(Player.SENTE, { row: 5, column: 5 });
+      const horse = bishop.promote();
+      
+      expect(horse.type).toBe(PieceType.HORSE);
+      expect(horse.player).toBe(Player.SENTE);
+      expect(horse.position).toEqual(bishop.position);
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/bishop.ts
+++ b/src/domain/models/piece/pieces/bishop.ts
@@ -1,0 +1,69 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 角クラス
+ */
+export class Bishop extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.BISHOP, player, position);
+  }
+
+  /**
+   * 角の移動可能な位置を計算
+   * 斜めに自由に移動可能（他の駒を飛び越えることはできない）
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const directions = [
+      { dr: -1, dc: -1 }, // 左上
+      { dr: -1, dc: 1 },  // 右上
+      { dr: 1, dc: -1 },  // 左下
+      { dr: 1, dc: 1 },   // 右下
+    ];
+
+    for (const { dr, dc } of directions) {
+      // 各方向に進めるだけ進む
+      for (let i = 1; i <= 8; i++) {
+        const newPosition: Position = {
+          row: this.position.row + dr * i,
+          column: this.position.column + dc * i,
+        };
+
+        if (!board.isValidPosition(newPosition)) {
+          break;
+        }
+
+        const pieceAtDestination = board.getPieceAt(newPosition);
+        
+        if (pieceAtDestination) {
+          // 敵の駒なら取れる
+          if (pieceAtDestination.player !== this.player) {
+            moves.push({
+              from: this.position,
+              to: newPosition,
+              isPromotion: this.canPromote(newPosition),
+            });
+          }
+          // 駒があったらそれ以上進めない
+          break;
+        }
+
+        moves.push({
+          from: this.position,
+          to: newPosition,
+          isPromotion: this.canPromote(newPosition),
+        });
+      }
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/dragon.test.ts
+++ b/src/domain/models/piece/pieces/dragon.test.ts
@@ -1,0 +1,145 @@
+import { Dragon } from './dragon';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Dragon（竜）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく竜を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const dragon = new Dragon(Player.SENTE, position);
+
+      expect(dragon.type).toBe(PieceType.DRAGON);
+      expect(dragon.player).toBe(Player.SENTE);
+      expect(dragon.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    it('飛車の動き（縦横）に加えて、斜め1マスに移動できる', () => {
+      const board = new MockBoard();
+      const dragon = new Dragon(Player.SENTE, { row: 5, column: 5 });
+      board.setPieceAt({ row: 5, column: 5 }, dragon);
+
+      const moves = dragon.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 飛車と同じ縦横の動き
+      // 上方向
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toContainEqual({ row: 3, column: 5 });
+      expect(destinations).toContainEqual({ row: 2, column: 5 });
+      expect(destinations).toContainEqual({ row: 1, column: 5 });
+      
+      // 下方向
+      expect(destinations).toContainEqual({ row: 6, column: 5 });
+      expect(destinations).toContainEqual({ row: 7, column: 5 });
+      expect(destinations).toContainEqual({ row: 8, column: 5 });
+      expect(destinations).toContainEqual({ row: 9, column: 5 });
+      
+      // 左方向
+      expect(destinations).toContainEqual({ row: 5, column: 4 });
+      expect(destinations).toContainEqual({ row: 5, column: 3 });
+      expect(destinations).toContainEqual({ row: 5, column: 2 });
+      expect(destinations).toContainEqual({ row: 5, column: 1 });
+      
+      // 右方向
+      expect(destinations).toContainEqual({ row: 5, column: 6 });
+      expect(destinations).toContainEqual({ row: 5, column: 7 });
+      expect(destinations).toContainEqual({ row: 5, column: 8 });
+      expect(destinations).toContainEqual({ row: 5, column: 9 });
+      
+      // 斜め1マス
+      expect(destinations).toContainEqual({ row: 4, column: 4 });
+      expect(destinations).toContainEqual({ row: 4, column: 6 });
+      expect(destinations).toContainEqual({ row: 6, column: 4 });
+      expect(destinations).toContainEqual({ row: 6, column: 6 });
+      
+      expect(destinations).toHaveLength(20);
+      
+      // 斜め2マス以上は移動できない
+      expect(destinations).not.toContainEqual({ row: 3, column: 3 });
+      expect(destinations).not.toContainEqual({ row: 7, column: 7 });
+    });
+
+    it('縦横の移動は他の駒を飛び越えることができない', () => {
+      const board = new MockBoard();
+      const dragon = new Dragon(Player.SENTE, { row: 5, column: 5 });
+      const blockingPiece = new Dragon(Player.GOTE, { row: 3, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, dragon);
+      board.setPieceAt({ row: 3, column: 5 }, blockingPiece);
+
+      const moves = dragon.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 敵の駒の位置までは移動できる
+      expect(destinations).toContainEqual({ row: 3, column: 5 });
+      // その先には移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 5 });
+      expect(destinations).not.toContainEqual({ row: 1, column: 5 });
+    });
+
+    it('斜め1マスの移動でも味方の駒がある場所には移動できない', () => {
+      const board = new MockBoard();
+      const dragon = new Dragon(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Dragon(Player.SENTE, { row: 4, column: 4 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, dragon);
+      board.setPieceAt({ row: 4, column: 4 }, allyPiece);
+
+      const moves = dragon.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).not.toContainEqual({ row: 4, column: 4 });
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const dragon = new Dragon(Player.SENTE);
+
+      const moves = dragon.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('竜は成れない（すでに成り駒）', () => {
+      const dragon = new Dragon(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(dragon.canPromote({ row: 1, column: 5 })).toBe(false);
+      expect(dragon.canPromote({ row: 3, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('promote', () => {
+    it('竜は成り駒に変換できない', () => {
+      const dragon = new Dragon(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(() => dragon.promote()).toThrow('この駒は成ることができません');
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/dragon.ts
+++ b/src/domain/models/piece/pieces/dragon.ts
@@ -1,0 +1,100 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 竜（成り飛車）クラス
+ */
+export class Dragon extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.DRAGON, player, position);
+  }
+
+  /**
+   * 竜の移動可能な位置を計算
+   * 飛車の動き（縦横自由）＋ 斜め1マス
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    
+    // 飛車と同じ縦横の動き
+    const straightDirections = [
+      { dr: -1, dc: 0 }, // 上
+      { dr: 1, dc: 0 },  // 下
+      { dr: 0, dc: -1 }, // 左
+      { dr: 0, dc: 1 },  // 右
+    ];
+
+    for (const { dr, dc } of straightDirections) {
+      // 各方向に進めるだけ進む
+      for (let i = 1; i <= 8; i++) {
+        const newPosition: Position = {
+          row: this.position.row + dr * i,
+          column: this.position.column + dc * i,
+        };
+
+        if (!board.isValidPosition(newPosition)) {
+          break;
+        }
+
+        const pieceAtDestination = board.getPieceAt(newPosition);
+        
+        if (pieceAtDestination) {
+          // 敵の駒なら取れる
+          if (pieceAtDestination.player !== this.player) {
+            moves.push({
+              from: this.position,
+              to: newPosition,
+            });
+          }
+          // 駒があったらそれ以上進めない
+          break;
+        }
+
+        moves.push({
+          from: this.position,
+          to: newPosition,
+        });
+      }
+    }
+
+    // 斜め1マスの動き
+    const diagonalDirections = [
+      { dr: -1, dc: -1 }, // 左上
+      { dr: -1, dc: 1 },  // 右上
+      { dr: 1, dc: -1 },  // 左下
+      { dr: 1, dc: 1 },   // 右下
+    ];
+
+    for (const { dr, dc } of diagonalDirections) {
+      const newPosition: Position = {
+        row: this.position.row + dr,
+        column: this.position.column + dc,
+      };
+
+      if (!board.isValidPosition(newPosition)) {
+        continue;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      // 移動先に味方の駒がある場合は移動不可
+      if (pieceAtDestination && pieceAtDestination.player === this.player) {
+        continue;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/gold.test.ts
+++ b/src/domain/models/piece/pieces/gold.test.ts
@@ -1,0 +1,143 @@
+import { Gold } from './gold';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Gold（金）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく金を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const gold = new Gold(Player.SENTE, position);
+
+      expect(gold.type).toBe(PieceType.GOLD);
+      expect(gold.player).toBe(Player.SENTE);
+      expect(gold.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    describe('先手の場合', () => {
+      it('前方3マス、横2マス、後方1マスに移動できる', () => {
+        const board = new MockBoard();
+        const gold = new Gold(Player.SENTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, gold);
+
+        const moves = gold.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 前方3マス
+        expect(destinations).toContainEqual({ row: 4, column: 4 });
+        expect(destinations).toContainEqual({ row: 4, column: 5 });
+        expect(destinations).toContainEqual({ row: 4, column: 6 });
+        // 横2マス
+        expect(destinations).toContainEqual({ row: 5, column: 4 });
+        expect(destinations).toContainEqual({ row: 5, column: 6 });
+        // 後方1マス
+        expect(destinations).toContainEqual({ row: 6, column: 5 });
+        
+        expect(destinations).toHaveLength(6);
+        // 斜め後ろには移動できない
+        expect(destinations).not.toContainEqual({ row: 6, column: 4 });
+        expect(destinations).not.toContainEqual({ row: 6, column: 6 });
+      });
+    });
+
+    describe('後手の場合', () => {
+      it('前方3マス、横2マス、後方1マスに移動できる（後手の向き）', () => {
+        const board = new MockBoard();
+        const gold = new Gold(Player.GOTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, gold);
+
+        const moves = gold.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 前方3マス（後手は下向き）
+        expect(destinations).toContainEqual({ row: 6, column: 4 });
+        expect(destinations).toContainEqual({ row: 6, column: 5 });
+        expect(destinations).toContainEqual({ row: 6, column: 6 });
+        // 横2マス
+        expect(destinations).toContainEqual({ row: 5, column: 4 });
+        expect(destinations).toContainEqual({ row: 5, column: 6 });
+        // 後方1マス
+        expect(destinations).toContainEqual({ row: 4, column: 5 });
+        
+        expect(destinations).toHaveLength(6);
+        // 斜め後ろには移動できない
+        expect(destinations).not.toContainEqual({ row: 4, column: 4 });
+        expect(destinations).not.toContainEqual({ row: 4, column: 6 });
+      });
+    });
+
+    it('盤面の端では移動可能マスが制限される', () => {
+      const board = new MockBoard();
+      const gold = new Gold(Player.SENTE, { row: 1, column: 1 });
+      board.setPieceAt({ row: 1, column: 1 }, gold);
+
+      const moves = gold.getValidMoves(board);
+      expect(moves).toHaveLength(2); // 右と下のみ
+    });
+
+    it('味方の駒がある場所には移動できない', () => {
+      const board = new MockBoard();
+      const gold = new Gold(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Gold(Player.SENTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, gold);
+      board.setPieceAt({ row: 4, column: 5 }, allyPiece);
+
+      const moves = gold.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).not.toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toHaveLength(5);
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const gold = new Gold(Player.SENTE);
+
+      const moves = gold.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('金は成れない', () => {
+      const gold = new Gold(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(gold.canPromote({ row: 1, column: 5 })).toBe(false);
+      expect(gold.canPromote({ row: 3, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('promote', () => {
+    it('金は成り駒に変換できない', () => {
+      const gold = new Gold(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(() => gold.promote()).toThrow('この駒は成ることができません');
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/gold.ts
+++ b/src/domain/models/piece/pieces/gold.ts
@@ -1,0 +1,65 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 金クラス
+ */
+export class Gold extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.GOLD, player, position);
+  }
+
+  /**
+   * 金の移動可能な位置を計算
+   * 前方3マス、横2マス、後方1マスに移動可能（斜め後ろは不可）
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const forward = this.player === Player.SENTE ? -1 : 1;
+    
+    // 移動可能な相対位置
+    const directions = [
+      // 前方3マス
+      { dr: forward, dc: -1 },
+      { dr: forward, dc: 0 },
+      { dr: forward, dc: 1 },
+      // 横2マス
+      { dr: 0, dc: -1 },
+      { dr: 0, dc: 1 },
+      // 後方1マス
+      { dr: -forward, dc: 0 },
+    ];
+
+    for (const { dr, dc } of directions) {
+      const newPosition: Position = {
+        row: this.position.row + dr,
+        column: this.position.column + dc,
+      };
+
+      if (!board.isValidPosition(newPosition)) {
+        continue;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      // 移動先に味方の駒がある場合は移動不可
+      if (pieceAtDestination && pieceAtDestination.player === this.player) {
+        continue;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/horse.test.ts
+++ b/src/domain/models/piece/pieces/horse.test.ts
@@ -1,0 +1,145 @@
+import { Horse } from './horse';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Horse（馬）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく馬を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const horse = new Horse(Player.SENTE, position);
+
+      expect(horse.type).toBe(PieceType.HORSE);
+      expect(horse.player).toBe(Player.SENTE);
+      expect(horse.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    it('角の動き（斜め）に加えて、縦横1マスに移動できる', () => {
+      const board = new MockBoard();
+      const horse = new Horse(Player.SENTE, { row: 5, column: 5 });
+      board.setPieceAt({ row: 5, column: 5 }, horse);
+
+      const moves = horse.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 角と同じ斜めの動き
+      // 左上方向
+      expect(destinations).toContainEqual({ row: 4, column: 4 });
+      expect(destinations).toContainEqual({ row: 3, column: 3 });
+      expect(destinations).toContainEqual({ row: 2, column: 2 });
+      expect(destinations).toContainEqual({ row: 1, column: 1 });
+      
+      // 右上方向
+      expect(destinations).toContainEqual({ row: 4, column: 6 });
+      expect(destinations).toContainEqual({ row: 3, column: 7 });
+      expect(destinations).toContainEqual({ row: 2, column: 8 });
+      expect(destinations).toContainEqual({ row: 1, column: 9 });
+      
+      // 左下方向
+      expect(destinations).toContainEqual({ row: 6, column: 4 });
+      expect(destinations).toContainEqual({ row: 7, column: 3 });
+      expect(destinations).toContainEqual({ row: 8, column: 2 });
+      expect(destinations).toContainEqual({ row: 9, column: 1 });
+      
+      // 右下方向
+      expect(destinations).toContainEqual({ row: 6, column: 6 });
+      expect(destinations).toContainEqual({ row: 7, column: 7 });
+      expect(destinations).toContainEqual({ row: 8, column: 8 });
+      expect(destinations).toContainEqual({ row: 9, column: 9 });
+      
+      // 縦横1マス
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toContainEqual({ row: 6, column: 5 });
+      expect(destinations).toContainEqual({ row: 5, column: 4 });
+      expect(destinations).toContainEqual({ row: 5, column: 6 });
+      
+      expect(destinations).toHaveLength(20);
+      
+      // 縦横2マス以上は移動できない
+      expect(destinations).not.toContainEqual({ row: 3, column: 5 });
+      expect(destinations).not.toContainEqual({ row: 5, column: 3 });
+    });
+
+    it('斜めの移動は他の駒を飛び越えることができない', () => {
+      const board = new MockBoard();
+      const horse = new Horse(Player.SENTE, { row: 5, column: 5 });
+      const blockingPiece = new Horse(Player.GOTE, { row: 3, column: 3 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, horse);
+      board.setPieceAt({ row: 3, column: 3 }, blockingPiece);
+
+      const moves = horse.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 敵の駒の位置までは移動できる
+      expect(destinations).toContainEqual({ row: 3, column: 3 });
+      // その先には移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 2 });
+      expect(destinations).not.toContainEqual({ row: 1, column: 1 });
+    });
+
+    it('縦横1マスの移動でも味方の駒がある場所には移動できない', () => {
+      const board = new MockBoard();
+      const horse = new Horse(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Horse(Player.SENTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, horse);
+      board.setPieceAt({ row: 4, column: 5 }, allyPiece);
+
+      const moves = horse.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).not.toContainEqual({ row: 4, column: 5 });
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const horse = new Horse(Player.SENTE);
+
+      const moves = horse.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('馬は成れない（すでに成り駒）', () => {
+      const horse = new Horse(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(horse.canPromote({ row: 1, column: 5 })).toBe(false);
+      expect(horse.canPromote({ row: 3, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('promote', () => {
+    it('馬は成り駒に変換できない', () => {
+      const horse = new Horse(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(() => horse.promote()).toThrow('この駒は成ることができません');
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/horse.ts
+++ b/src/domain/models/piece/pieces/horse.ts
@@ -1,0 +1,100 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 馬（成り角）クラス
+ */
+export class Horse extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.HORSE, player, position);
+  }
+
+  /**
+   * 馬の移動可能な位置を計算
+   * 角の動き（斜め自由）＋ 縦横1マス
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    
+    // 角と同じ斜めの動き
+    const diagonalDirections = [
+      { dr: -1, dc: -1 }, // 左上
+      { dr: -1, dc: 1 },  // 右上
+      { dr: 1, dc: -1 },  // 左下
+      { dr: 1, dc: 1 },   // 右下
+    ];
+
+    for (const { dr, dc } of diagonalDirections) {
+      // 各方向に進めるだけ進む
+      for (let i = 1; i <= 8; i++) {
+        const newPosition: Position = {
+          row: this.position.row + dr * i,
+          column: this.position.column + dc * i,
+        };
+
+        if (!board.isValidPosition(newPosition)) {
+          break;
+        }
+
+        const pieceAtDestination = board.getPieceAt(newPosition);
+        
+        if (pieceAtDestination) {
+          // 敵の駒なら取れる
+          if (pieceAtDestination.player !== this.player) {
+            moves.push({
+              from: this.position,
+              to: newPosition,
+            });
+          }
+          // 駒があったらそれ以上進めない
+          break;
+        }
+
+        moves.push({
+          from: this.position,
+          to: newPosition,
+        });
+      }
+    }
+
+    // 縦横1マスの動き
+    const straightDirections = [
+      { dr: -1, dc: 0 }, // 上
+      { dr: 1, dc: 0 },  // 下
+      { dr: 0, dc: -1 }, // 左
+      { dr: 0, dc: 1 },  // 右
+    ];
+
+    for (const { dr, dc } of straightDirections) {
+      const newPosition: Position = {
+        row: this.position.row + dr,
+        column: this.position.column + dc,
+      };
+
+      if (!board.isValidPosition(newPosition)) {
+        continue;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      // 移動先に味方の駒がある場合は移動不可
+      if (pieceAtDestination && pieceAtDestination.player === this.player) {
+        continue;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/index.ts
+++ b/src/domain/models/piece/pieces/index.ts
@@ -1,0 +1,14 @@
+export { King } from './king';
+export { Rook } from './rook';
+export { Bishop } from './bishop';
+export { Gold } from './gold';
+export { Silver } from './silver';
+export { Knight } from './knight';
+export { Lance } from './lance';
+export { Pawn } from './pawn';
+export { Dragon } from './dragon';
+export { Horse } from './horse';
+export { PromotedSilver } from './promoted-silver';
+export { PromotedKnight } from './promoted-knight';
+export { PromotedLance } from './promoted-lance';
+export { Tokin } from './tokin';

--- a/src/domain/models/piece/pieces/king.test.ts
+++ b/src/domain/models/piece/pieces/king.test.ts
@@ -1,0 +1,130 @@
+import { King } from './king';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('King（玉）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく玉を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const king = new King(Player.SENTE, position);
+
+      expect(king.type).toBe(PieceType.KING);
+      expect(king.player).toBe(Player.SENTE);
+      expect(king.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    it('周囲8マスに移動できる', () => {
+      const board = new MockBoard();
+      const king = new King(Player.SENTE, { row: 5, column: 5 });
+      board.setPieceAt({ row: 5, column: 5 }, king);
+
+      const moves = king.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).toContainEqual({ row: 4, column: 4 });
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toContainEqual({ row: 4, column: 6 });
+      expect(destinations).toContainEqual({ row: 5, column: 4 });
+      expect(destinations).toContainEqual({ row: 5, column: 6 });
+      expect(destinations).toContainEqual({ row: 6, column: 4 });
+      expect(destinations).toContainEqual({ row: 6, column: 5 });
+      expect(destinations).toContainEqual({ row: 6, column: 6 });
+      expect(destinations).toHaveLength(8);
+    });
+
+    it('盤面の端では移動可能マスが制限される', () => {
+      const board = new MockBoard();
+      const king = new King(Player.SENTE, { row: 1, column: 1 });
+      board.setPieceAt({ row: 1, column: 1 }, king);
+
+      const moves = king.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).toContainEqual({ row: 1, column: 2 });
+      expect(destinations).toContainEqual({ row: 2, column: 1 });
+      expect(destinations).toContainEqual({ row: 2, column: 2 });
+      expect(destinations).toHaveLength(3);
+    });
+
+    it('味方の駒がある場所には移動できない', () => {
+      const board = new MockBoard();
+      const king = new King(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new King(Player.SENTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, king);
+      board.setPieceAt({ row: 4, column: 5 }, allyPiece);
+
+      const moves = king.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).not.toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toHaveLength(7);
+    });
+
+    it('敵の駒がある場所には移動できる（取れる）', () => {
+      const board = new MockBoard();
+      const king = new King(Player.SENTE, { row: 5, column: 5 });
+      const enemyPiece = new King(Player.GOTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, king);
+      board.setPieceAt({ row: 4, column: 5 }, enemyPiece);
+
+      const moves = king.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toHaveLength(8);
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const king = new King(Player.SENTE);
+
+      const moves = king.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('玉は成れない', () => {
+      const king = new King(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(king.canPromote({ row: 1, column: 5 })).toBe(false);
+      expect(king.canPromote({ row: 3, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('promote', () => {
+    it('玉は成り駒に変換できない', () => {
+      const king = new King(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(() => king.promote()).toThrow('この駒は成ることができません');
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/king.ts
+++ b/src/domain/models/piece/pieces/king.ts
@@ -1,0 +1,56 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 玉クラス
+ */
+export class King extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.KING, player, position);
+  }
+
+  /**
+   * 玉の移動可能な位置を計算
+   * 周囲8マスに移動可能
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const directions = [
+      { dr: -1, dc: -1 }, { dr: -1, dc: 0 }, { dr: -1, dc: 1 },
+      { dr: 0, dc: -1 },                     { dr: 0, dc: 1 },
+      { dr: 1, dc: -1 },  { dr: 1, dc: 0 },  { dr: 1, dc: 1 },
+    ];
+
+    for (const { dr, dc } of directions) {
+      const newPosition: Position = {
+        row: this.position.row + dr,
+        column: this.position.column + dc,
+      };
+
+      if (!board.isValidPosition(newPosition)) {
+        continue;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      // 移動先に味方の駒がある場合は移動不可
+      if (pieceAtDestination && pieceAtDestination.player === this.player) {
+        continue;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/knight.test.ts
+++ b/src/domain/models/piece/pieces/knight.test.ts
@@ -1,0 +1,191 @@
+import { Knight } from './knight';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Knight（桂馬）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく桂馬を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const knight = new Knight(Player.SENTE, position);
+
+      expect(knight.type).toBe(PieceType.KNIGHT);
+      expect(knight.player).toBe(Player.SENTE);
+      expect(knight.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    describe('先手の場合', () => {
+      it('前方斜め2マスに移動できる', () => {
+        const board = new MockBoard();
+        const knight = new Knight(Player.SENTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, knight);
+
+        const moves = knight.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 左前方
+        expect(destinations).toContainEqual({ row: 3, column: 4 });
+        // 右前方
+        expect(destinations).toContainEqual({ row: 3, column: 6 });
+        
+        expect(destinations).toHaveLength(2);
+        
+        // 他の方向には移動できない
+        expect(destinations).not.toContainEqual({ row: 7, column: 4 });
+        expect(destinations).not.toContainEqual({ row: 7, column: 6 });
+        expect(destinations).not.toContainEqual({ row: 4, column: 5 });
+      });
+
+      it('盤面の端では移動可能マスが制限される', () => {
+        const board = new MockBoard();
+        const knight = new Knight(Player.SENTE, { row: 3, column: 1 });
+        board.setPieceAt({ row: 3, column: 1 }, knight);
+
+        const moves = knight.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 右前方のみ
+        expect(destinations).toContainEqual({ row: 1, column: 2 });
+        expect(destinations).toHaveLength(1);
+      });
+
+      it('1段目、2段目では移動できない（移動先がない）', () => {
+        const board = new MockBoard();
+        const knight1 = new Knight(Player.SENTE, { row: 1, column: 5 });
+        const knight2 = new Knight(Player.SENTE, { row: 2, column: 5 });
+        board.setPieceAt({ row: 1, column: 5 }, knight1);
+        board.setPieceAt({ row: 2, column: 5 }, knight2);
+
+        expect(knight1.getValidMoves(board)).toHaveLength(0);
+        expect(knight2.getValidMoves(board)).toHaveLength(0);
+      });
+    });
+
+    describe('後手の場合', () => {
+      it('前方斜め2マスに移動できる（後手の向き）', () => {
+        const board = new MockBoard();
+        const knight = new Knight(Player.GOTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, knight);
+
+        const moves = knight.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 左前方（後手は下向き）
+        expect(destinations).toContainEqual({ row: 7, column: 4 });
+        // 右前方
+        expect(destinations).toContainEqual({ row: 7, column: 6 });
+        
+        expect(destinations).toHaveLength(2);
+      });
+
+      it('8段目、9段目では移動できない（移動先がない）', () => {
+        const board = new MockBoard();
+        const knight1 = new Knight(Player.GOTE, { row: 8, column: 5 });
+        const knight2 = new Knight(Player.GOTE, { row: 9, column: 5 });
+        board.setPieceAt({ row: 8, column: 5 }, knight1);
+        board.setPieceAt({ row: 9, column: 5 }, knight2);
+
+        expect(knight1.getValidMoves(board)).toHaveLength(0);
+        expect(knight2.getValidMoves(board)).toHaveLength(0);
+      });
+    });
+
+    it('味方の駒がある場所には移動できない', () => {
+      const board = new MockBoard();
+      const knight = new Knight(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Knight(Player.SENTE, { row: 3, column: 4 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, knight);
+      board.setPieceAt({ row: 3, column: 4 }, allyPiece);
+
+      const moves = knight.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).not.toContainEqual({ row: 3, column: 4 });
+      expect(destinations).toHaveLength(1);
+    });
+
+    it('他の駒を飛び越えて移動できる', () => {
+      const board = new MockBoard();
+      const knight = new Knight(Player.SENTE, { row: 5, column: 5 });
+      const blockingPiece = new Knight(Player.GOTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, knight);
+      board.setPieceAt({ row: 4, column: 5 }, blockingPiece);
+
+      const moves = knight.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 前に駒があっても飛び越えて移動できる
+      expect(destinations).toContainEqual({ row: 3, column: 4 });
+      expect(destinations).toContainEqual({ row: 3, column: 6 });
+      expect(destinations).toHaveLength(2);
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const knight = new Knight(Player.SENTE);
+
+      const moves = knight.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('先手の場合、敵陣に入る時に成れる', () => {
+      const knight = new Knight(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(knight.canPromote({ row: 3, column: 4 })).toBe(true);
+    });
+
+    it('先手の場合、3段目から1段目への移動時は強制的に成る必要がある', () => {
+      const knight = new Knight(Player.SENTE, { row: 3, column: 5 });
+      
+      // この実装では canPromote は true を返すが、
+      // 実際のゲームロジックでは強制成りの判定が必要
+      expect(knight.canPromote({ row: 1, column: 4 })).toBe(true);
+    });
+
+    it('後手の場合、敵陣に入る時に成れる', () => {
+      const knight = new Knight(Player.GOTE, { row: 5, column: 5 });
+      
+      expect(knight.canPromote({ row: 7, column: 4 })).toBe(true);
+    });
+  });
+
+  describe('promote', () => {
+    it('桂馬を成桂に変換できる', () => {
+      const knight = new Knight(Player.SENTE, { row: 5, column: 5 });
+      const promoted = knight.promote();
+      
+      expect(promoted.type).toBe(PieceType.PROMOTED_KNIGHT);
+      expect(promoted.player).toBe(Player.SENTE);
+      expect(promoted.position).toEqual(knight.position);
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/knight.ts
+++ b/src/domain/models/piece/pieces/knight.ts
@@ -1,0 +1,54 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 桂馬クラス
+ */
+export class Knight extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.KNIGHT, player, position);
+  }
+
+  /**
+   * 桂馬の移動可能な位置を計算
+   * 前方斜め2マスに移動可能（他の駒を飛び越えることができる）
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const forward = this.player === Player.SENTE ? -2 : 2;
+    
+    // 桂馬の移動先（前方斜め2マス）
+    const destinations = [
+      { row: this.position.row + forward, column: this.position.column - 1 },
+      { row: this.position.row + forward, column: this.position.column + 1 },
+    ];
+
+    for (const newPosition of destinations) {
+      if (!board.isValidPosition(newPosition)) {
+        continue;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      // 移動先に味方の駒がある場合は移動不可
+      if (pieceAtDestination && pieceAtDestination.player === this.player) {
+        continue;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+        isPromotion: this.canPromote(newPosition),
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/lance.test.ts
+++ b/src/domain/models/piece/pieces/lance.test.ts
@@ -1,0 +1,183 @@
+import { Lance } from './lance';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Lance（香車）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく香車を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const lance = new Lance(Player.SENTE, position);
+
+      expect(lance.type).toBe(PieceType.LANCE);
+      expect(lance.player).toBe(Player.SENTE);
+      expect(lance.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    describe('先手の場合', () => {
+      it('前方に自由に移動できる', () => {
+        const board = new MockBoard();
+        const lance = new Lance(Player.SENTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, lance);
+
+        const moves = lance.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 前方のみ
+        expect(destinations).toContainEqual({ row: 4, column: 5 });
+        expect(destinations).toContainEqual({ row: 3, column: 5 });
+        expect(destinations).toContainEqual({ row: 2, column: 5 });
+        expect(destinations).toContainEqual({ row: 1, column: 5 });
+        
+        expect(destinations).toHaveLength(4);
+        
+        // 横や後ろには移動できない
+        expect(destinations).not.toContainEqual({ row: 6, column: 5 });
+        expect(destinations).not.toContainEqual({ row: 5, column: 4 });
+        expect(destinations).not.toContainEqual({ row: 5, column: 6 });
+      });
+
+      it('1段目では移動できない（移動先がない）', () => {
+        const board = new MockBoard();
+        const lance = new Lance(Player.SENTE, { row: 1, column: 5 });
+        board.setPieceAt({ row: 1, column: 5 }, lance);
+
+        const moves = lance.getValidMoves(board);
+        expect(moves).toHaveLength(0);
+      });
+    });
+
+    describe('後手の場合', () => {
+      it('前方に自由に移動できる（後手の向き）', () => {
+        const board = new MockBoard();
+        const lance = new Lance(Player.GOTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, lance);
+
+        const moves = lance.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 前方のみ（後手は下向き）
+        expect(destinations).toContainEqual({ row: 6, column: 5 });
+        expect(destinations).toContainEqual({ row: 7, column: 5 });
+        expect(destinations).toContainEqual({ row: 8, column: 5 });
+        expect(destinations).toContainEqual({ row: 9, column: 5 });
+        
+        expect(destinations).toHaveLength(4);
+      });
+
+      it('9段目では移動できない（移動先がない）', () => {
+        const board = new MockBoard();
+        const lance = new Lance(Player.GOTE, { row: 9, column: 5 });
+        board.setPieceAt({ row: 9, column: 5 }, lance);
+
+        const moves = lance.getValidMoves(board);
+        expect(moves).toHaveLength(0);
+      });
+    });
+
+    it('他の駒を飛び越えることはできない', () => {
+      const board = new MockBoard();
+      const lance = new Lance(Player.SENTE, { row: 5, column: 5 });
+      const blockingPiece = new Lance(Player.GOTE, { row: 3, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, lance);
+      board.setPieceAt({ row: 3, column: 5 }, blockingPiece);
+
+      const moves = lance.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 敵の駒の位置までは移動できる
+      expect(destinations).toContainEqual({ row: 3, column: 5 });
+      // その先には移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 5 });
+      expect(destinations).not.toContainEqual({ row: 1, column: 5 });
+      expect(destinations).toHaveLength(2); // 4と3のみ
+    });
+
+    it('味方の駒の手前までしか移動できない', () => {
+      const board = new MockBoard();
+      const lance = new Lance(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Lance(Player.SENTE, { row: 3, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, lance);
+      board.setPieceAt({ row: 3, column: 5 }, allyPiece);
+
+      const moves = lance.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 味方の駒の手前まで
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      // 味方の駒の位置には移動できない
+      expect(destinations).not.toContainEqual({ row: 3, column: 5 });
+      expect(destinations).toHaveLength(1);
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const lance = new Lance(Player.SENTE);
+
+      const moves = lance.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('先手の場合、敵陣に入る時に成れる', () => {
+      const lance = new Lance(Player.SENTE, { row: 4, column: 5 });
+      
+      expect(lance.canPromote({ row: 3, column: 5 })).toBe(true);
+      expect(lance.canPromote({ row: 2, column: 5 })).toBe(true);
+    });
+
+    it('先手の場合、2段目から1段目への移動時は強制的に成る必要がある', () => {
+      const lance = new Lance(Player.SENTE, { row: 2, column: 5 });
+      
+      // この実装では canPromote は true を返すが、
+      // 実際のゲームロジックでは強制成りの判定が必要
+      expect(lance.canPromote({ row: 1, column: 5 })).toBe(true);
+    });
+
+    it('後手の場合、敵陣に入る時に成れる', () => {
+      const lance = new Lance(Player.GOTE, { row: 6, column: 5 });
+      
+      expect(lance.canPromote({ row: 7, column: 5 })).toBe(true);
+      expect(lance.canPromote({ row: 8, column: 5 })).toBe(true);
+    });
+  });
+
+  describe('promote', () => {
+    it('香車を成香に変換できる', () => {
+      const lance = new Lance(Player.SENTE, { row: 5, column: 5 });
+      const promoted = lance.promote();
+      
+      expect(promoted.type).toBe(PieceType.PROMOTED_LANCE);
+      expect(promoted.player).toBe(Player.SENTE);
+      expect(promoted.position).toEqual(lance.position);
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/lance.ts
+++ b/src/domain/models/piece/pieces/lance.ts
@@ -1,0 +1,62 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 香車クラス
+ */
+export class Lance extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.LANCE, player, position);
+  }
+
+  /**
+   * 香車の移動可能な位置を計算
+   * 前方に自由に移動可能（他の駒を飛び越えることはできない）
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const forward = this.player === Player.SENTE ? -1 : 1;
+
+    // 前方に進めるだけ進む
+    for (let i = 1; i <= 8; i++) {
+      const newPosition: Position = {
+        row: this.position.row + forward * i,
+        column: this.position.column,
+      };
+
+      if (!board.isValidPosition(newPosition)) {
+        break;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      if (pieceAtDestination) {
+        // 敵の駒なら取れる
+        if (pieceAtDestination.player !== this.player) {
+          moves.push({
+            from: this.position,
+            to: newPosition,
+            isPromotion: this.canPromote(newPosition),
+          });
+        }
+        // 駒があったらそれ以上進めない
+        break;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+        isPromotion: this.canPromote(newPosition),
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/pawn.test.ts
+++ b/src/domain/models/piece/pieces/pawn.test.ts
@@ -1,0 +1,168 @@
+import { Pawn } from './pawn';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Pawn（歩）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく歩を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const pawn = new Pawn(Player.SENTE, position);
+
+      expect(pawn.type).toBe(PieceType.PAWN);
+      expect(pawn.player).toBe(Player.SENTE);
+      expect(pawn.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    describe('先手の場合', () => {
+      it('前方1マスに移動できる', () => {
+        const board = new MockBoard();
+        const pawn = new Pawn(Player.SENTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, pawn);
+
+        const moves = pawn.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        expect(destinations).toContainEqual({ row: 4, column: 5 });
+        expect(destinations).toHaveLength(1);
+        
+        // 横や後ろ、斜めには移動できない
+        expect(destinations).not.toContainEqual({ row: 6, column: 5 });
+        expect(destinations).not.toContainEqual({ row: 5, column: 4 });
+        expect(destinations).not.toContainEqual({ row: 5, column: 6 });
+        expect(destinations).not.toContainEqual({ row: 4, column: 4 });
+      });
+
+      it('1段目では移動できない（移動先がない）', () => {
+        const board = new MockBoard();
+        const pawn = new Pawn(Player.SENTE, { row: 1, column: 5 });
+        board.setPieceAt({ row: 1, column: 5 }, pawn);
+
+        const moves = pawn.getValidMoves(board);
+        expect(moves).toHaveLength(0);
+      });
+    });
+
+    describe('後手の場合', () => {
+      it('前方1マスに移動できる（後手の向き）', () => {
+        const board = new MockBoard();
+        const pawn = new Pawn(Player.GOTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, pawn);
+
+        const moves = pawn.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        expect(destinations).toContainEqual({ row: 6, column: 5 });
+        expect(destinations).toHaveLength(1);
+      });
+
+      it('9段目では移動できない（移動先がない）', () => {
+        const board = new MockBoard();
+        const pawn = new Pawn(Player.GOTE, { row: 9, column: 5 });
+        board.setPieceAt({ row: 9, column: 5 }, pawn);
+
+        const moves = pawn.getValidMoves(board);
+        expect(moves).toHaveLength(0);
+      });
+    });
+
+    it('前に敵の駒がある場合は取れる', () => {
+      const board = new MockBoard();
+      const pawn = new Pawn(Player.SENTE, { row: 5, column: 5 });
+      const enemyPiece = new Pawn(Player.GOTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, pawn);
+      board.setPieceAt({ row: 4, column: 5 }, enemyPiece);
+
+      const moves = pawn.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toHaveLength(1);
+    });
+
+    it('前に味方の駒がある場合は移動できない', () => {
+      const board = new MockBoard();
+      const pawn = new Pawn(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Pawn(Player.SENTE, { row: 4, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, pawn);
+      board.setPieceAt({ row: 4, column: 5 }, allyPiece);
+
+      const moves = pawn.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const pawn = new Pawn(Player.SENTE);
+
+      const moves = pawn.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('先手の場合、敵陣に入る時に成れる', () => {
+      const pawn = new Pawn(Player.SENTE, { row: 4, column: 5 });
+      
+      expect(pawn.canPromote({ row: 3, column: 5 })).toBe(true);
+    });
+
+    it('先手の場合、2段目から1段目への移動時は強制的に成る必要がある', () => {
+      const pawn = new Pawn(Player.SENTE, { row: 2, column: 5 });
+      
+      // この実装では canPromote は true を返すが、
+      // 実際のゲームロジックでは強制成りの判定が必要
+      expect(pawn.canPromote({ row: 1, column: 5 })).toBe(true);
+    });
+
+    it('後手の場合、敵陣に入る時に成れる', () => {
+      const pawn = new Pawn(Player.GOTE, { row: 6, column: 5 });
+      
+      expect(pawn.canPromote({ row: 7, column: 5 })).toBe(true);
+    });
+
+    it('敵陣外での移動では成れない', () => {
+      const pawn = new Pawn(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(pawn.canPromote({ row: 4, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('promote', () => {
+    it('歩をと金に変換できる', () => {
+      const pawn = new Pawn(Player.SENTE, { row: 5, column: 5 });
+      const tokin = pawn.promote();
+      
+      expect(tokin.type).toBe(PieceType.TOKIN);
+      expect(tokin.player).toBe(Player.SENTE);
+      expect(tokin.position).toEqual(pawn.position);
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/pawn.ts
+++ b/src/domain/models/piece/pieces/pawn.ts
@@ -1,0 +1,51 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 歩クラス
+ */
+export class Pawn extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.PAWN, player, position);
+  }
+
+  /**
+   * 歩の移動可能な位置を計算
+   * 前方1マスのみ移動可能
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const forward = this.player === Player.SENTE ? -1 : 1;
+
+    const newPosition: Position = {
+      row: this.position.row + forward,
+      column: this.position.column,
+    };
+
+    if (!board.isValidPosition(newPosition)) {
+      return moves;
+    }
+
+    const pieceAtDestination = board.getPieceAt(newPosition);
+    
+    // 移動先に味方の駒がある場合は移動不可
+    if (pieceAtDestination && pieceAtDestination.player === this.player) {
+      return moves;
+    }
+
+    moves.push({
+      from: this.position,
+      to: newPosition,
+      isPromotion: this.canPromote(newPosition),
+    });
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/promoted-knight.ts
+++ b/src/domain/models/piece/pieces/promoted-knight.ts
@@ -1,0 +1,19 @@
+import { Gold } from './gold';
+import { PieceType, Player, Position } from '../types';
+
+/**
+ * 成桂クラス
+ * 金と同じ動きをする
+ */
+export class PromotedKnight extends Gold {
+  constructor(player: Player, position: Position | null = null) {
+    super(player, position);
+    // typeを成桂に上書き
+    Object.defineProperty(this, 'type', {
+      value: PieceType.PROMOTED_KNIGHT,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+  }
+}

--- a/src/domain/models/piece/pieces/promoted-lance.ts
+++ b/src/domain/models/piece/pieces/promoted-lance.ts
@@ -1,0 +1,19 @@
+import { Gold } from './gold';
+import { PieceType, Player, Position } from '../types';
+
+/**
+ * 成香クラス
+ * 金と同じ動きをする
+ */
+export class PromotedLance extends Gold {
+  constructor(player: Player, position: Position | null = null) {
+    super(player, position);
+    // typeを成香に上書き
+    Object.defineProperty(this, 'type', {
+      value: PieceType.PROMOTED_LANCE,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+  }
+}

--- a/src/domain/models/piece/pieces/promoted-pieces.test.ts
+++ b/src/domain/models/piece/pieces/promoted-pieces.test.ts
@@ -1,0 +1,144 @@
+import { PromotedSilver } from './promoted-silver';
+import { PromotedKnight } from './promoted-knight';
+import { PromotedLance } from './promoted-lance';
+import { Tokin } from './tokin';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+// 成銀、成桂、成香、と金は全て金と同じ動きをするため、共通のテストを使用
+const promotedPieceTestCases = [
+  { name: 'PromotedSilver（成銀）', PieceClass: PromotedSilver, type: PieceType.PROMOTED_SILVER },
+  { name: 'PromotedKnight（成桂）', PieceClass: PromotedKnight, type: PieceType.PROMOTED_KNIGHT },
+  { name: 'PromotedLance（成香）', PieceClass: PromotedLance, type: PieceType.PROMOTED_LANCE },
+  { name: 'Tokin（と金）', PieceClass: Tokin, type: PieceType.TOKIN },
+];
+
+promotedPieceTestCases.forEach(({ name, PieceClass, type }) => {
+  describe(name, () => {
+    describe('コンストラクタ', () => {
+      it(`正しく${name}を作成できる`, () => {
+        const position: Position = { row: 5, column: 5 };
+        const piece = new PieceClass(Player.SENTE, position);
+
+        expect(piece.type).toBe(type);
+        expect(piece.player).toBe(Player.SENTE);
+        expect(piece.position).toEqual(position);
+      });
+    });
+
+    describe('getValidMoves', () => {
+      describe('先手の場合', () => {
+        it('金と同じく前方3マス、横2マス、後方1マスに移動できる', () => {
+          const board = new MockBoard();
+          const piece = new PieceClass(Player.SENTE, { row: 5, column: 5 });
+          board.setPieceAt({ row: 5, column: 5 }, piece);
+
+          const moves = piece.getValidMoves(board);
+          const destinations = moves.map(move => move.to);
+
+          // 前方3マス
+          expect(destinations).toContainEqual({ row: 4, column: 4 });
+          expect(destinations).toContainEqual({ row: 4, column: 5 });
+          expect(destinations).toContainEqual({ row: 4, column: 6 });
+          // 横2マス
+          expect(destinations).toContainEqual({ row: 5, column: 4 });
+          expect(destinations).toContainEqual({ row: 5, column: 6 });
+          // 後方1マス
+          expect(destinations).toContainEqual({ row: 6, column: 5 });
+          
+          expect(destinations).toHaveLength(6);
+          // 斜め後ろには移動できない
+          expect(destinations).not.toContainEqual({ row: 6, column: 4 });
+          expect(destinations).not.toContainEqual({ row: 6, column: 6 });
+        });
+      });
+
+      describe('後手の場合', () => {
+        it('金と同じく前方3マス、横2マス、後方1マスに移動できる（後手の向き）', () => {
+          const board = new MockBoard();
+          const piece = new PieceClass(Player.GOTE, { row: 5, column: 5 });
+          board.setPieceAt({ row: 5, column: 5 }, piece);
+
+          const moves = piece.getValidMoves(board);
+          const destinations = moves.map(move => move.to);
+
+          // 前方3マス（後手は下向き）
+          expect(destinations).toContainEqual({ row: 6, column: 4 });
+          expect(destinations).toContainEqual({ row: 6, column: 5 });
+          expect(destinations).toContainEqual({ row: 6, column: 6 });
+          // 横2マス
+          expect(destinations).toContainEqual({ row: 5, column: 4 });
+          expect(destinations).toContainEqual({ row: 5, column: 6 });
+          // 後方1マス
+          expect(destinations).toContainEqual({ row: 4, column: 5 });
+          
+          expect(destinations).toHaveLength(6);
+        });
+      });
+
+      it('味方の駒がある場所には移動できない', () => {
+        const board = new MockBoard();
+        const piece = new PieceClass(Player.SENTE, { row: 5, column: 5 });
+        const allyPiece = new PieceClass(Player.SENTE, { row: 4, column: 5 });
+        
+        board.setPieceAt({ row: 5, column: 5 }, piece);
+        board.setPieceAt({ row: 4, column: 5 }, allyPiece);
+
+        const moves = piece.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        expect(destinations).not.toContainEqual({ row: 4, column: 5 });
+        expect(destinations).toHaveLength(5);
+      });
+
+      it('持ち駒の場合は移動できない', () => {
+        const board = new MockBoard();
+        const piece = new PieceClass(Player.SENTE);
+
+        const moves = piece.getValidMoves(board);
+        expect(moves).toHaveLength(0);
+      });
+    });
+
+    describe('canPromote', () => {
+      it('成り駒は成れない', () => {
+        const piece = new PieceClass(Player.SENTE, { row: 5, column: 5 });
+        
+        expect(piece.canPromote({ row: 1, column: 5 })).toBe(false);
+        expect(piece.canPromote({ row: 3, column: 5 })).toBe(false);
+      });
+    });
+
+    describe('promote', () => {
+      it('成り駒は成り駒に変換できない', () => {
+        const piece = new PieceClass(Player.SENTE, { row: 5, column: 5 });
+        
+        expect(() => piece.promote()).toThrow('この駒は成ることができません');
+      });
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/promoted-silver.ts
+++ b/src/domain/models/piece/pieces/promoted-silver.ts
@@ -1,0 +1,19 @@
+import { Gold } from './gold';
+import { PieceType, Player, Position } from '../types';
+
+/**
+ * 成銀クラス
+ * 金と同じ動きをする
+ */
+export class PromotedSilver extends Gold {
+  constructor(player: Player, position: Position | null = null) {
+    super(player, position);
+    // typeを成銀に上書き
+    Object.defineProperty(this, 'type', {
+      value: PieceType.PROMOTED_SILVER,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+  }
+}

--- a/src/domain/models/piece/pieces/rook.test.ts
+++ b/src/domain/models/piece/pieces/rook.test.ts
@@ -1,0 +1,158 @@
+import { Rook } from './rook';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Rook（飛車）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく飛車を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const rook = new Rook(Player.SENTE, position);
+
+      expect(rook.type).toBe(PieceType.ROOK);
+      expect(rook.player).toBe(Player.SENTE);
+      expect(rook.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    it('縦横に自由に移動できる', () => {
+      const board = new MockBoard();
+      const rook = new Rook(Player.SENTE, { row: 5, column: 5 });
+      board.setPieceAt({ row: 5, column: 5 }, rook);
+
+      const moves = rook.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 上方向
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      expect(destinations).toContainEqual({ row: 3, column: 5 });
+      expect(destinations).toContainEqual({ row: 2, column: 5 });
+      expect(destinations).toContainEqual({ row: 1, column: 5 });
+      
+      // 下方向
+      expect(destinations).toContainEqual({ row: 6, column: 5 });
+      expect(destinations).toContainEqual({ row: 7, column: 5 });
+      expect(destinations).toContainEqual({ row: 8, column: 5 });
+      expect(destinations).toContainEqual({ row: 9, column: 5 });
+      
+      // 左方向
+      expect(destinations).toContainEqual({ row: 5, column: 4 });
+      expect(destinations).toContainEqual({ row: 5, column: 3 });
+      expect(destinations).toContainEqual({ row: 5, column: 2 });
+      expect(destinations).toContainEqual({ row: 5, column: 1 });
+      
+      // 右方向
+      expect(destinations).toContainEqual({ row: 5, column: 6 });
+      expect(destinations).toContainEqual({ row: 5, column: 7 });
+      expect(destinations).toContainEqual({ row: 5, column: 8 });
+      expect(destinations).toContainEqual({ row: 5, column: 9 });
+      
+      expect(destinations).toHaveLength(16);
+      
+      // 斜めには移動できない
+      expect(destinations).not.toContainEqual({ row: 4, column: 4 });
+      expect(destinations).not.toContainEqual({ row: 6, column: 6 });
+    });
+
+    it('他の駒を飛び越えることはできない', () => {
+      const board = new MockBoard();
+      const rook = new Rook(Player.SENTE, { row: 5, column: 5 });
+      const blockingPiece = new Rook(Player.GOTE, { row: 3, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, rook);
+      board.setPieceAt({ row: 3, column: 5 }, blockingPiece);
+
+      const moves = rook.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 敵の駒の位置までは移動できる
+      expect(destinations).toContainEqual({ row: 3, column: 5 });
+      // その先には移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 5 });
+      expect(destinations).not.toContainEqual({ row: 1, column: 5 });
+    });
+
+    it('味方の駒の手前までしか移動できない', () => {
+      const board = new MockBoard();
+      const rook = new Rook(Player.SENTE, { row: 5, column: 5 });
+      const allyPiece = new Rook(Player.SENTE, { row: 3, column: 5 });
+      
+      board.setPieceAt({ row: 5, column: 5 }, rook);
+      board.setPieceAt({ row: 3, column: 5 }, allyPiece);
+
+      const moves = rook.getValidMoves(board);
+      const destinations = moves.map(move => move.to);
+
+      // 味方の駒の手前まで
+      expect(destinations).toContainEqual({ row: 4, column: 5 });
+      // 味方の駒の位置には移動できない
+      expect(destinations).not.toContainEqual({ row: 3, column: 5 });
+      // その先にも移動できない
+      expect(destinations).not.toContainEqual({ row: 2, column: 5 });
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const rook = new Rook(Player.SENTE);
+
+      const moves = rook.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('敵陣に入る時に成れる', () => {
+      const rook = new Rook(Player.SENTE, { row: 4, column: 5 });
+      
+      expect(rook.canPromote({ row: 3, column: 5 })).toBe(true);
+      expect(rook.canPromote({ row: 2, column: 5 })).toBe(true);
+    });
+
+    it('敵陣から出る時も成れる', () => {
+      const rook = new Rook(Player.SENTE, { row: 3, column: 5 });
+      
+      expect(rook.canPromote({ row: 4, column: 5 })).toBe(true);
+    });
+
+    it('敵陣内での移動でも成れる', () => {
+      const rook = new Rook(Player.SENTE, { row: 2, column: 5 });
+      
+      expect(rook.canPromote({ row: 1, column: 5 })).toBe(true);
+    });
+  });
+
+  describe('promote', () => {
+    it('飛車を竜に変換できる', () => {
+      const rook = new Rook(Player.SENTE, { row: 5, column: 5 });
+      const dragon = rook.promote();
+      
+      expect(dragon.type).toBe(PieceType.DRAGON);
+      expect(dragon.player).toBe(Player.SENTE);
+      expect(dragon.position).toEqual(rook.position);
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/rook.ts
+++ b/src/domain/models/piece/pieces/rook.ts
@@ -1,0 +1,69 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 飛車クラス
+ */
+export class Rook extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.ROOK, player, position);
+  }
+
+  /**
+   * 飛車の移動可能な位置を計算
+   * 縦横に自由に移動可能（他の駒を飛び越えることはできない）
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const directions = [
+      { dr: -1, dc: 0 }, // 上
+      { dr: 1, dc: 0 },  // 下
+      { dr: 0, dc: -1 }, // 左
+      { dr: 0, dc: 1 },  // 右
+    ];
+
+    for (const { dr, dc } of directions) {
+      // 各方向に進めるだけ進む
+      for (let i = 1; i <= 8; i++) {
+        const newPosition: Position = {
+          row: this.position.row + dr * i,
+          column: this.position.column + dc * i,
+        };
+
+        if (!board.isValidPosition(newPosition)) {
+          break;
+        }
+
+        const pieceAtDestination = board.getPieceAt(newPosition);
+        
+        if (pieceAtDestination) {
+          // 敵の駒なら取れる
+          if (pieceAtDestination.player !== this.player) {
+            moves.push({
+              from: this.position,
+              to: newPosition,
+              isPromotion: this.canPromote(newPosition),
+            });
+          }
+          // 駒があったらそれ以上進めない
+          break;
+        }
+
+        moves.push({
+          from: this.position,
+          to: newPosition,
+          isPromotion: this.canPromote(newPosition),
+        });
+      }
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/silver.test.ts
+++ b/src/domain/models/piece/pieces/silver.test.ts
@@ -1,0 +1,137 @@
+import { Silver } from './silver';
+import { PieceType, Player, Position } from '../types';
+import { IBoard, IPiece } from '../interface';
+
+// モックボードの作成
+class MockBoard implements IBoard {
+  private pieces: Map<string, IPiece>;
+
+  constructor() {
+    this.pieces = new Map();
+  }
+
+  getPieceAt(position: Position): IPiece | null {
+    const key = `${position.row}-${position.column}`;
+    return this.pieces.get(key) || null;
+  }
+
+  isValidPosition(position: Position): boolean {
+    return position.row >= 1 && position.row <= 9 && 
+           position.column >= 1 && position.column <= 9;
+  }
+
+  setPieceAt(position: Position, piece: IPiece): void {
+    const key = `${position.row}-${position.column}`;
+    this.pieces.set(key, piece);
+  }
+}
+
+describe('Silver（銀）', () => {
+  describe('コンストラクタ', () => {
+    it('正しく銀を作成できる', () => {
+      const position: Position = { row: 5, column: 5 };
+      const silver = new Silver(Player.SENTE, position);
+
+      expect(silver.type).toBe(PieceType.SILVER);
+      expect(silver.player).toBe(Player.SENTE);
+      expect(silver.position).toEqual(position);
+    });
+  });
+
+  describe('getValidMoves', () => {
+    describe('先手の場合', () => {
+      it('前方3マス、斜め後ろ2マスに移動できる', () => {
+        const board = new MockBoard();
+        const silver = new Silver(Player.SENTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, silver);
+
+        const moves = silver.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 前方3マス
+        expect(destinations).toContainEqual({ row: 4, column: 4 });
+        expect(destinations).toContainEqual({ row: 4, column: 5 });
+        expect(destinations).toContainEqual({ row: 4, column: 6 });
+        // 斜め後ろ2マス
+        expect(destinations).toContainEqual({ row: 6, column: 4 });
+        expect(destinations).toContainEqual({ row: 6, column: 6 });
+        
+        expect(destinations).toHaveLength(5);
+        // 横と真後ろには移動できない
+        expect(destinations).not.toContainEqual({ row: 5, column: 4 });
+        expect(destinations).not.toContainEqual({ row: 5, column: 6 });
+        expect(destinations).not.toContainEqual({ row: 6, column: 5 });
+      });
+    });
+
+    describe('後手の場合', () => {
+      it('前方3マス、斜め後ろ2マスに移動できる（後手の向き）', () => {
+        const board = new MockBoard();
+        const silver = new Silver(Player.GOTE, { row: 5, column: 5 });
+        board.setPieceAt({ row: 5, column: 5 }, silver);
+
+        const moves = silver.getValidMoves(board);
+        const destinations = moves.map(move => move.to);
+
+        // 前方3マス（後手は下向き）
+        expect(destinations).toContainEqual({ row: 6, column: 4 });
+        expect(destinations).toContainEqual({ row: 6, column: 5 });
+        expect(destinations).toContainEqual({ row: 6, column: 6 });
+        // 斜め後ろ2マス
+        expect(destinations).toContainEqual({ row: 4, column: 4 });
+        expect(destinations).toContainEqual({ row: 4, column: 6 });
+        
+        expect(destinations).toHaveLength(5);
+      });
+    });
+
+    it('盤面の端では移動可能マスが制限される', () => {
+      const board = new MockBoard();
+      const silver = new Silver(Player.SENTE, { row: 1, column: 1 });
+      board.setPieceAt({ row: 1, column: 1 }, silver);
+
+      const moves = silver.getValidMoves(board);
+      expect(moves).toHaveLength(2); // 下と右下のみ
+    });
+
+    it('持ち駒の場合は移動できない', () => {
+      const board = new MockBoard();
+      const silver = new Silver(Player.SENTE);
+
+      const moves = silver.getValidMoves(board);
+      expect(moves).toHaveLength(0);
+    });
+  });
+
+  describe('canPromote', () => {
+    it('敵陣に入る時に成れる', () => {
+      const silver = new Silver(Player.SENTE, { row: 4, column: 5 });
+      
+      expect(silver.canPromote({ row: 3, column: 5 })).toBe(true);
+      expect(silver.canPromote({ row: 2, column: 5 })).toBe(true);
+    });
+
+    it('敵陣から出る時も成れる', () => {
+      const silver = new Silver(Player.SENTE, { row: 3, column: 5 });
+      
+      expect(silver.canPromote({ row: 4, column: 5 })).toBe(true);
+    });
+
+    it('敵陣外での移動では成れない', () => {
+      const silver = new Silver(Player.SENTE, { row: 5, column: 5 });
+      
+      expect(silver.canPromote({ row: 6, column: 5 })).toBe(false);
+    });
+  });
+
+  describe('promote', () => {
+    it('銀を成銀に変換できる', () => {
+      const silver = new Silver(Player.SENTE, { row: 5, column: 5 });
+      const promoted = silver.promote();
+      
+      expect(promoted.type).toBe(PieceType.PROMOTED_SILVER);
+      expect(promoted.player).toBe(Player.SENTE);
+      expect(promoted.position).toEqual(silver.position);
+    });
+  });
+});

--- a/src/domain/models/piece/pieces/silver.ts
+++ b/src/domain/models/piece/pieces/silver.ts
@@ -1,0 +1,64 @@
+import { Piece } from '../piece';
+import { PieceType, Player, Position, Move } from '../types';
+import { IBoard } from '../interface';
+
+/**
+ * 銀クラス
+ */
+export class Silver extends Piece {
+  constructor(player: Player, position: Position | null = null) {
+    super(PieceType.SILVER, player, position);
+  }
+
+  /**
+   * 銀の移動可能な位置を計算
+   * 前方3マス、斜め後ろ2マスに移動可能
+   * @param board 現在の盤面状態
+   * @returns 移動可能な位置の配列
+   */
+  getValidMoves(board: IBoard): Move[] {
+    if (!this.position) {
+      return [];
+    }
+
+    const moves: Move[] = [];
+    const forward = this.player === Player.SENTE ? -1 : 1;
+    
+    // 移動可能な相対位置
+    const directions = [
+      // 前方3マス
+      { dr: forward, dc: -1 },
+      { dr: forward, dc: 0 },
+      { dr: forward, dc: 1 },
+      // 斜め後ろ2マス
+      { dr: -forward, dc: -1 },
+      { dr: -forward, dc: 1 },
+    ];
+
+    for (const { dr, dc } of directions) {
+      const newPosition: Position = {
+        row: this.position.row + dr,
+        column: this.position.column + dc,
+      };
+
+      if (!board.isValidPosition(newPosition)) {
+        continue;
+      }
+
+      const pieceAtDestination = board.getPieceAt(newPosition);
+      
+      // 移動先に味方の駒がある場合は移動不可
+      if (pieceAtDestination && pieceAtDestination.player === this.player) {
+        continue;
+      }
+
+      moves.push({
+        from: this.position,
+        to: newPosition,
+        isPromotion: this.canPromote(newPosition),
+      });
+    }
+
+    return moves;
+  }
+}

--- a/src/domain/models/piece/pieces/tokin.ts
+++ b/src/domain/models/piece/pieces/tokin.ts
@@ -1,0 +1,19 @@
+import { Gold } from './gold';
+import { PieceType, Player, Position } from '../types';
+
+/**
+ * と金クラス
+ * 金と同じ動きをする
+ */
+export class Tokin extends Gold {
+  constructor(player: Player, position: Position | null = null) {
+    super(player, position);
+    // typeをと金に上書き
+    Object.defineProperty(this, 'type', {
+      value: PieceType.TOKIN,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+  }
+}

--- a/src/domain/models/piece/types.ts
+++ b/src/domain/models/piece/types.ts
@@ -1,0 +1,44 @@
+/**
+ * 駒の種類を表すEnum
+ */
+export enum PieceType {
+  KING = 'KING',           // 玉
+  ROOK = 'ROOK',           // 飛車
+  BISHOP = 'BISHOP',       // 角
+  GOLD = 'GOLD',           // 金
+  SILVER = 'SILVER',       // 銀
+  KNIGHT = 'KNIGHT',       // 桂馬
+  LANCE = 'LANCE',         // 香車
+  PAWN = 'PAWN',           // 歩
+  DRAGON = 'DRAGON',       // 竜（成り飛車）
+  HORSE = 'HORSE',         // 馬（成り角）
+  PROMOTED_SILVER = 'PROMOTED_SILVER', // 成銀
+  PROMOTED_KNIGHT = 'PROMOTED_KNIGHT', // 成桂
+  PROMOTED_LANCE = 'PROMOTED_LANCE',   // 成香
+  TOKIN = 'TOKIN',         // と金（成り歩）
+}
+
+/**
+ * プレイヤーを表すEnum
+ */
+export enum Player {
+  SENTE = 'SENTE', // 先手
+  GOTE = 'GOTE',   // 後手
+}
+
+/**
+ * 駒の位置を表す型
+ */
+export interface Position {
+  row: number;    // 1-9
+  column: number; // 1-9
+}
+
+/**
+ * 移動可能な位置の型
+ */
+export interface Move {
+  from: Position;
+  to: Position;
+  isPromotion?: boolean; // 成りの可否
+}


### PR DESCRIPTION
## 概要
将棋の各駒を表現するPieceクラスをTDDで実装しました。

## 変更内容
- クリーンアーキテクチャに基づいたドメイン層の構築
- 8種類の基本駒（玉、飛、角、金、銀、桂、香、歩）の実装
- 6種類の成り駒（竜、馬、成銀、成桂、成香、と金）の実装
- 各駒の移動可能範囲の計算ロジック
- 成り駒への変換処理
- ファクトリ関数による駒の生成
- 全てのクラスに対する単体テスト

Closes #4

Generated with [Claude Code](https://claude.ai/code)