### PR TITLE
refactor: PieceとGameRulesのcanPromoteロジックの責務を分離する

### DIFF
--- a/src/domain/models/piece/interface.ts
+++ b/src/domain/models/piece/interface.ts
@@ -20,12 +20,6 @@ export interface IPiece {
    */
   getValidMoves(board: IBoard): Position[];
   
-  /**
-   * 成り駒への変換が可能かチェック
-   * @param to 移動先の位置
-   * @returns 成り可能な場合true
-   */
-  canPromote(to: Position): boolean;
   
   /**
    * 成り駒に変換

--- a/src/domain/models/piece/piece.test.ts
+++ b/src/domain/models/piece/piece.test.ts
@@ -101,32 +101,6 @@ describe('Piece', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('先手の駒が敵陣に入れば成れること', () => {
-      const piece = createPiece(PieceType.PAWN, Player.SENTE, {
-        row: 2,
-        column: 0,
-      });
-      // 移動後の位置を渡して判定
-      expect(piece.canPromote({ row: 2, column: 0 })).toBe(true);
-    });
-
-    it('後手の駒が敵陣に入れば成れること', () => {
-      const piece = createPiece(PieceType.PAWN, Player.GOTE, {
-        row: 6,
-        column: 0,
-      });
-      expect(piece.canPromote({ row: 6, column: 0 })).toBe(true);
-    });
-
-    it('敵陣にいない場合は成れないこと', () => {
-      const piece = createPiece(PieceType.PAWN, Player.SENTE, {
-        row: 3,
-        column: 0,
-      });
-      expect(piece.canPromote({ row: 3, column: 0 })).toBe(false);
-    });
-  });
 
   describe('getValidMoves', () => {
     let board: IBoard;

--- a/src/domain/models/piece/piece.ts
+++ b/src/domain/models/piece/piece.ts
@@ -22,35 +22,6 @@ export abstract class Piece implements IPiece {
    */
   abstract getValidMoves(board: IBoard): Position[];
 
-  /**
-   * 成り駒への変換が可能かチェック
-   * @param to 移動先の位置
-   * @returns 成り可能な場合true
-   */
-  canPromote(to: Position): boolean {
-    // 持ち駒は成れない
-    if (!this.position) {
-      return false;
-    }
-
-    // 金と玉は成れない
-    if (this.type === PieceType.GOLD || this.type === PieceType.KING) {
-      return false;
-    }
-
-    // すでに成り駒は成れない
-    if (this.isPromoted()) {
-      return false;
-    }
-
-    // 先手の場合：敵陣は0-2段目
-    if (this.player === Player.SENTE) {
-      return to.row <= 2 || this.position.row <= 2;
-    }
-    
-    // 後手の場合：敵陣は6-8段目
-    return to.row >= 6 || this.position.row >= 6;
-  }
 
   /**
    * 成り駒に変換

--- a/src/domain/models/piece/pieces/dragon.test.ts
+++ b/src/domain/models/piece/pieces/dragon.test.ts
@@ -99,14 +99,6 @@ describe('Dragon', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('竜は成れない（すでに成り駒）', () => {
-      const dragon = new Dragon(Player.SENTE, { row: 4, column: 4 });
-      
-      expect(dragon.canPromote({ row: 0, column: 4 })).toBe(false);
-      expect(dragon.canPromote({ row: 2, column: 4 })).toBe(false);
-    });
-  });
 
   describe('promote', () => {
     it('竜は成り駒に変換できない', () => {

--- a/src/domain/models/piece/pieces/gold.test.ts
+++ b/src/domain/models/piece/pieces/gold.test.ts
@@ -80,12 +80,6 @@ describe('Gold', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('金は成れない', () => {
-      const gold = new Gold(Player.SENTE, { row: 4, column: 4 });
-      expect(gold.canPromote({ row: 2, column: 4 })).toBe(false);
-    });
-  });
 
   describe('promote', () => {
     it('金は成り駒に変換できない', () => {

--- a/src/domain/models/piece/pieces/horse.test.ts
+++ b/src/domain/models/piece/pieces/horse.test.ts
@@ -86,12 +86,6 @@ describe('Horse', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('馬は成れない（すでに成り駒）', () => {
-      const horse = new Horse(Player.SENTE, { row: 4, column: 4 });
-      expect(horse.canPromote({ row: 2, column: 4 })).toBe(false);
-    });
-  });
 
   describe('promote', () => {
     it('馬は成り駒に変換できない', () => {

--- a/src/domain/models/piece/pieces/king.test.ts
+++ b/src/domain/models/piece/pieces/king.test.ts
@@ -66,12 +66,6 @@ describe('King', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('玉は成れない', () => {
-      const king = new King(Player.SENTE, { row: 4, column: 4 });
-      expect(king.canPromote({ row: 2, column: 4 })).toBe(false);
-    });
-  });
 
   describe('promote', () => {
     it('玉は成り駒に変換できない', () => {

--- a/src/domain/models/piece/pieces/knight.test.ts
+++ b/src/domain/models/piece/pieces/knight.test.ts
@@ -74,12 +74,6 @@ describe('Knight', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('先手の場合、敵陣に入る時に成れる', () => {
-      const knight = new Knight(Player.SENTE, { row: 4, column: 2 });
-      expect(knight.canPromote({ row: 2, column: 1 })).toBe(true);
-    });
-  });
 
   describe('promote', () => {
     it('桂馬を成桂に変換できる', () => {

--- a/src/domain/models/piece/pieces/lance.test.ts
+++ b/src/domain/models/piece/pieces/lance.test.ts
@@ -79,12 +79,6 @@ describe('Lance', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('先手の場合、敵陣に入る時に成れる', () => {
-      const lance = new Lance(Player.SENTE, { row: 4, column: 0 });
-      expect(lance.canPromote({ row: 2, column: 0 })).toBe(true);
-    });
-  });
 
   describe('promote', () => {
     it('香車を成香に変換できる', () => {

--- a/src/domain/models/piece/pieces/pawn.test.ts
+++ b/src/domain/models/piece/pieces/pawn.test.ts
@@ -109,33 +109,6 @@ describe('Pawn', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('先手の場合、敵陣に入る時に成れる', () => {
-      const pawn = new Pawn(Player.SENTE, { row: 3, column: 5 });
-      
-      expect(pawn.canPromote({ row: 2, column: 5 })).toBe(true);
-    });
-
-    it('先手の場合、2段目から1段目への移動時は強制的に成る必要がある', () => {
-      const pawn = new Pawn(Player.SENTE, { row: 2, column: 5 });
-      
-      // この実装では canPromote は true を返すが、
-      // 実際のゲームロジックでは強制成りの判定が必要
-      expect(pawn.canPromote({ row: 0, column: 4 })).toBe(true);
-    });
-
-    it('後手の場合、敵陣に入る時に成れる', () => {
-      const pawn = new Pawn(Player.GOTE, { row: 5, column: 4 }); // 5六歩
-      
-      expect(pawn.canPromote({ row: 6, column: 4 })).toBe(true);
-    });
-
-    it('敵陣外での移動では成れない', () => {
-      const pawn = new Pawn(Player.SENTE, { row: 4, column: 4 }); // 5五歩
-      
-      expect(pawn.canPromote({ row: 3, column: 4 })).toBe(false);
-    });
-  });
 
   describe('promote', () => {
     it('歩をと金に変換できる', () => {

--- a/src/domain/models/piece/pieces/promoted-pieces.test.ts
+++ b/src/domain/models/piece/pieces/promoted-pieces.test.ts
@@ -153,14 +153,6 @@ promotedPieceTestCases.forEach(({ name, PieceClass, type }) => {
       });
     });
 
-    describe('canPromote', () => {
-      it('成り駒は成れない', () => {
-        const piece = new PieceClass(Player.SENTE, { row: 4, column: 4 });
-        
-        expect(piece.canPromote({ row: 2, column: 4 })).toBe(false);
-        expect(piece.canPromote({ row: 0, column: 4 })).toBe(false);
-      });
-    });
 
     describe('promote', () => {
       it('成り駒は成り駒に変換できない', () => {

--- a/src/domain/models/piece/pieces/rook.test.ts
+++ b/src/domain/models/piece/pieces/rook.test.ts
@@ -154,26 +154,6 @@ describe('Rook（飛車）', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('敵陣に入る時に成れる', () => {
-      const rook = new Rook(Player.SENTE, { row: 3, column: 4 });
-      
-      expect(rook.canPromote({ row: 2, column: 4 })).toBe(true);
-      expect(rook.canPromote({ row: 1, column: 4 })).toBe(true);
-    });
-
-    it('敵陣から出る時も成れる', () => {
-      const rook = new Rook(Player.SENTE, { row: 2, column: 4 });
-      
-      expect(rook.canPromote({ row: 3, column: 4 })).toBe(true);
-    });
-
-    it('敵陣内での移動でも成れる', () => {
-      const rook = new Rook(Player.SENTE, { row: 1, column: 4 });
-      
-      expect(rook.canPromote({ row: 0, column: 4 })).toBe(true);
-    });
-  });
 
   describe('promote', () => {
     it('飛車を竜に変換できる', () => {

--- a/src/domain/models/piece/pieces/silver.test.ts
+++ b/src/domain/models/piece/pieces/silver.test.ts
@@ -136,26 +136,6 @@ describe('Silver（銀）', () => {
     });
   });
 
-  describe('canPromote', () => {
-    it('敵陣に入る時に成れる', () => {
-      const silver = new Silver(Player.SENTE, { row: 3, column: 4 });
-      
-      expect(silver.canPromote({ row: 2, column: 4 })).toBe(true);
-      expect(silver.canPromote({ row: 1, column: 4 })).toBe(true);
-    });
-
-    it('敵陣から出る時も成れる', () => {
-      const silver = new Silver(Player.SENTE, { row: 2, column: 4 });
-      
-      expect(silver.canPromote({ row: 3, column: 4 })).toBe(true);
-    });
-
-    it('敵陣外での移動では成れない', () => {
-      const silver = new Silver(Player.SENTE, { row: 4, column: 4 });
-      
-      expect(silver.canPromote({ row: 3, column: 4 })).toBe(false);
-    });
-  });
 
   describe('promote', () => {
     it('銀を成銀に変換できる', () => {


### PR DESCRIPTION
## 概要
- PieceクラスとGameRulesクラスのcanPromoteロジックの重複を解消
- 成りに関するルール判定の責務をGameRulesに完全に集約

Fixes #25

Generated with [Claude Code](https://claude.ai/code)