### PR TITLE
feat: 将棋盤UIコンポーネントの実装（BoardUI）

### DIFF
--- a/src/app/board-demo/page.tsx
+++ b/src/app/board-demo/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { BoardUI, CellPosition } from '@/components/features/shogi';
+
+export default function BoardDemoPage() {
+  const [selectedCell, setSelectedCell] = useState<CellPosition | null>(null);
+  const [highlightedCells, setHighlightedCells] = useState<CellPosition[]>([]);
+  
+  const handleCellClick = (position: CellPosition) => {
+    setSelectedCell(position);
+    
+    // デモ用：選択したマスの周囲をハイライト
+    const newHighlights: CellPosition[] = [];
+    const { row, col } = position;
+    
+    // 上下左右のマスをハイライト
+    const directions = [
+      { dr: -1, dc: 0 }, // 上
+      { dr: 1, dc: 0 },  // 下
+      { dr: 0, dc: -1 }, // 左
+      { dr: 0, dc: 1 },  // 右
+    ];
+    
+    directions.forEach(({ dr, dc }) => {
+      const newRow = row + dr;
+      const newCol = col + dc;
+      if (newRow >= 0 && newRow < 9 && newCol >= 0 && newCol < 9) {
+        newHighlights.push({ row: newRow, col: newCol });
+      }
+    });
+    
+    setHighlightedCells(newHighlights);
+  };
+  
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4">
+        <h1 className="text-3xl font-bold text-center mb-8">
+          将棋盤UIコンポーネント デモ
+        </h1>
+        
+        <div className="mb-4 text-center text-gray-600">
+          <p>マスをクリックすると選択状態（青）になり、</p>
+          <p>その周囲のマスが移動可能マス（緑）として表示されます。</p>
+        </div>
+        
+        <BoardUI
+          selectedCell={selectedCell}
+          highlightedCells={highlightedCells}
+          onCellClick={handleCellClick}
+        />
+        
+        <div className="mt-8 text-center">
+          {selectedCell && (
+            <p className="text-lg">
+              選択中: {['一', '二', '三', '四', '五', '六', '七', '八', '九'][selectedCell.row]}
+              {9 - selectedCell.col}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/shogi/BoardUI.test.tsx
+++ b/src/components/features/shogi/BoardUI.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BoardUI } from './BoardUI';
+
+describe('BoardUI', () => {
+  it('将棋盤を9×9のグリッドで描画する', () => {
+    render(<BoardUI />);
+    const cells = screen.getAllByRole('button');
+    expect(cells).toHaveLength(81); // 9×9 = 81マス
+  });
+
+  it('横座標（1-9）を表示する', () => {
+    render(<BoardUI />);
+    for (let i = 1; i <= 9; i++) {
+      const coords = screen.getAllByText(i.toString());
+      expect(coords.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('縦座標（一-九）を表示する', () => {
+    render(<BoardUI />);
+    const kanjiNumbers = ['一', '二', '三', '四', '五', '六', '七', '八', '九'];
+    kanjiNumbers.forEach(kanji => {
+      const coords = screen.getAllByText(kanji);
+      expect(coords.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('マスをクリックするとonCellClickが呼ばれる', () => {
+    const handleCellClick = vi.fn();
+    render(<BoardUI onCellClick={handleCellClick} />);
+    
+    const cells = screen.getAllByRole('button');
+    fireEvent.click(cells[0]); // 左上のマスをクリック
+    
+    expect(handleCellClick).toHaveBeenCalledWith({ row: 0, col: 0 });
+  });
+
+  it('選択されたマスがハイライトされる', () => {
+    render(<BoardUI selectedCell={{ row: 4, col: 4 }} />);
+    
+    const cells = screen.getAllByRole('button');
+    const selectedCell = cells[4 * 9 + 4]; // 5行5列目（0-indexed）
+    
+    expect(selectedCell).toHaveClass('bg-blue-500');
+  });
+
+  it('移動可能なマスがハイライトされる', () => {
+    const highlightedCells = [
+      { row: 3, col: 4 },
+      { row: 5, col: 4 }
+    ];
+    render(<BoardUI highlightedCells={highlightedCells} />);
+    
+    const cells = screen.getAllByRole('button');
+    const firstHighlighted = cells[3 * 9 + 4];
+    const secondHighlighted = cells[5 * 9 + 4];
+    
+    expect(firstHighlighted).toHaveClass('bg-green-500');
+    expect(secondHighlighted).toHaveClass('bg-green-500');
+  });
+
+  it('レスポンシブで正方形を保つ', () => {
+    const { container } = render(<BoardUI />);
+    const board = container.querySelector('.aspect-square');
+    expect(board).toBeInTheDocument();
+  });
+});

--- a/src/components/features/shogi/BoardUI.tsx
+++ b/src/components/features/shogi/BoardUI.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+import { clsx } from 'clsx';
+
+export interface CellPosition {
+  row: number;
+  col: number;
+}
+
+interface BoardUIProps {
+  onCellClick?: (position: CellPosition) => void;
+  selectedCell?: CellPosition | null;
+  highlightedCells?: CellPosition[];
+}
+
+export const BoardUI: React.FC<BoardUIProps> = ({
+  onCellClick,
+  selectedCell,
+  highlightedCells = []
+}) => {
+  const kanjiNumbers = ['一', '二', '三', '四', '五', '六', '七', '八', '九'];
+  
+  const isCellSelected = (row: number, col: number): boolean => {
+    return selectedCell?.row === row && selectedCell?.col === col;
+  };
+  
+  const isCellHighlighted = (row: number, col: number): boolean => {
+    return highlightedCells.some(cell => cell.row === row && cell.col === col);
+  };
+  
+  const handleCellClick = (row: number, col: number) => {
+    onCellClick?.({ row, col });
+  };
+  
+  return (
+    <div className="w-full max-w-2xl mx-auto p-4">
+      <div className="aspect-square bg-amber-100 rounded-lg shadow-lg p-4">
+        <div className="grid grid-cols-[auto_repeat(9,1fr)] grid-rows-[auto_repeat(9,1fr)] gap-0 h-full">
+          {/* 左上の空白セル */}
+          <div className=""></div>
+          
+          {/* 上部の座標（1-9） */}
+          {Array.from({ length: 9 }, (_, i) => (
+            <div key={`top-${i}`} className="flex items-center justify-center text-sm font-bold">
+              {9 - i}
+            </div>
+          ))}
+          
+          {/* 各行 */}
+          {Array.from({ length: 9 }, (_, row) => (
+            <React.Fragment key={`row-${row}`}>
+              {/* 左側の座標（一-九） */}
+              <div className="flex items-center justify-center text-sm font-bold">
+                {kanjiNumbers[row]}
+              </div>
+              
+              {/* マス目 */}
+              {Array.from({ length: 9 }, (_, col) => {
+                const actualCol = 8 - col; // 将棋盤は右から左へ
+                return (
+                  <button
+                    key={`cell-${row}-${col}`}
+                    onClick={() => handleCellClick(row, actualCol)}
+                    className={clsx(
+                      'border border-gray-800 transition-colors duration-200',
+                      'hover:bg-amber-200 focus:outline-none focus:ring-2 focus:ring-blue-400',
+                      {
+                        'bg-blue-500 hover:bg-blue-600': isCellSelected(row, actualCol),
+                        'bg-green-500 hover:bg-green-600': isCellHighlighted(row, actualCol) && !isCellSelected(row, actualCol),
+                        'bg-amber-50': !isCellSelected(row, actualCol) && !isCellHighlighted(row, actualCol)
+                      }
+                    )}
+                    aria-label={`${kanjiNumbers[row]}${9 - col}`}
+                  />
+                );
+              })}
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/features/shogi/index.ts
+++ b/src/components/features/shogi/index.ts
@@ -1,0 +1,2 @@
+export { BoardUI } from './BoardUI';
+export type { CellPosition } from './BoardUI';


### PR DESCRIPTION
## 概要
将棋盤を表示するReactコンポーネントを実装しました。

Closes #7

## 変更内容
- BoardUIコンポーネントの作成
- 9×9グリッドレイアウト実装
- 座標表示（1-9、一-九）
- クリックイベントハンドリング
- 選択中・移動可能マスのハイライト機能
- レスポンシブ対応（aspect-square使用）
- TDDアプローチで全テスト実装
- デモページ作成（/board-demo）

Generated with [Claude Code](https://claude.ai/code)